### PR TITLE
Find and fix a bug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ This is a new project in early development following a phased approach. See `pla
 ### Citation Engine
 **Location:** `src/lib/citation/`
 
-- **Source Types (12):** Books, Academic Journals, Websites, Blogs, Newspapers, Videos, Images, Film, TV Series, TV Episode, Miscellaneous
+- **Source Types (11):** Books, Academic Journals, Websites, Blogs, Newspapers, Videos, Images, Film, TV Series, TV Episode, Miscellaneous
 - **Access Types (5):** Print, Database, Web, App, Archive
 - **Citation Styles (Core 4):** APA 7th, MLA 9th, Chicago 17th, Harvard
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -16,7 +16,7 @@ A citation manager, generator, and sharing tool with a Wikipedia 2005-inspired U
 ### 1.1 Citation Engine (Priority: HIGH)
 **Location:** `src/lib/citation/`
 
-#### Source Types (MVP - 12 types)
+#### Source Types (MVP - 11 types)
 | Type | Description |
 |------|-------------|
 | Books | Physical and eBooks |


### PR DESCRIPTION
The documentation claimed 12 source types but only listed 11: Books, Academic Journals, Websites, Blogs, Newspapers, Videos, Images, Film, TV Series, TV Episode, Miscellaneous.

Fixed in both CLAUDE.md and PLAN.md.