### PR TITLE
Add PWA offline support and Electron desktop app

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://raw.githubusercontent.com/electron-userland/electron-builder/master/packages/app-builder-lib/scheme.json",
+  "appId": "com.opencitation.app",
+  "productName": "OpenCitation",
+  "copyright": "Copyright © 2024 OpenCitation",
+  "directories": {
+    "output": "release",
+    "buildResources": "build"
+  },
+  "files": [
+    "dist-electron/**/*",
+    "out/**/*",
+    "public/**/*",
+    "!**/*.map"
+  ],
+  "extraResources": [
+    {
+      "from": "public/icons",
+      "to": "icons"
+    }
+  ],
+  "mac": {
+    "target": [
+      {
+        "target": "dmg",
+        "arch": ["universal"]
+      },
+      {
+        "target": "zip",
+        "arch": ["universal"]
+      }
+    ],
+    "icon": "public/icon.png",
+    "category": "public.app-category.education",
+    "hardenedRuntime": true,
+    "gatekeeperAssess": false,
+    "entitlements": "build/entitlements.mac.plist",
+    "entitlementsInherit": "build/entitlements.mac.plist",
+    "darkModeSupport": true,
+    "minimumSystemVersion": "10.15"
+  },
+  "win": {
+    "target": [
+      {
+        "target": "nsis",
+        "arch": ["x64", "arm64"]
+      },
+      {
+        "target": "portable",
+        "arch": ["x64"]
+      }
+    ],
+    "icon": "public/icon.png",
+    "publisherName": "OpenCitation"
+  },
+  "nsis": {
+    "oneClick": false,
+    "allowToChangeInstallationDirectory": true,
+    "installerIcon": "public/icon.png",
+    "uninstallerIcon": "public/icon.png",
+    "installerHeaderIcon": "public/icon.png",
+    "createDesktopShortcut": true,
+    "createStartMenuShortcut": true,
+    "shortcutName": "OpenCitation"
+  },
+  "linux": {
+    "target": [
+      {
+        "target": "AppImage",
+        "arch": ["x64", "arm64"]
+      },
+      {
+        "target": "deb",
+        "arch": ["x64", "arm64"]
+      },
+      {
+        "target": "rpm",
+        "arch": ["x64"]
+      }
+    ],
+    "icon": "public/icons",
+    "category": "Education",
+    "synopsis": "Free Citation Generator",
+    "description": "Generate, organize, and share citations in APA, MLA, Chicago, and Harvard formats.",
+    "desktop": {
+      "Name": "OpenCitation",
+      "Comment": "Free Citation Generator",
+      "Categories": "Education;Utility;Office",
+      "Keywords": "citation;bibliography;reference;APA;MLA;Chicago;Harvard"
+    }
+  },
+  "protocols": [
+    {
+      "name": "OpenCitation URL",
+      "schemes": ["opencitation"]
+    }
+  ],
+  "publish": {
+    "provider": "github",
+    "owner": "opencitation",
+    "repo": "opencitation"
+  }
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,0 +1,384 @@
+/**
+ * OpenCitation Electron Main Process
+ * Desktop application wrapper for the PWA
+ */
+
+import { app, BrowserWindow, Menu, shell, ipcMain, nativeTheme, Notification } from 'electron';
+import * as path from 'path';
+import * as url from 'url';
+
+const isDev = process.env.NODE_ENV === 'development';
+const PORT = process.env.PORT || 3000;
+
+let mainWindow: BrowserWindow | null = null;
+let isQuitting = false;
+
+// Single instance lock
+const gotTheLock = app.requestSingleInstanceLock();
+
+if (!gotTheLock) {
+  app.quit();
+} else {
+  app.on('second-instance', () => {
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) mainWindow.restore();
+      mainWindow.focus();
+    }
+  });
+}
+
+function createWindow(): void {
+  mainWindow = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    minWidth: 800,
+    minHeight: 600,
+    title: 'OpenCitation',
+    icon: path.join(__dirname, '../public/icon.png'),
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, 'preload.js'),
+      webSecurity: true,
+      allowRunningInsecureContent: false,
+    },
+    show: false,
+    backgroundColor: '#f9f9f9',
+    titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
+  });
+
+  // Load the app
+  const startUrl = isDev
+    ? `http://localhost:${PORT}`
+    : url.format({
+        pathname: path.join(__dirname, '../out/index.html'),
+        protocol: 'file:',
+        slashes: true,
+      });
+
+  mainWindow.loadURL(startUrl);
+
+  // Show window when ready
+  mainWindow.once('ready-to-show', () => {
+    mainWindow?.show();
+    if (isDev) {
+      mainWindow?.webContents.openDevTools();
+    }
+  });
+
+  // Handle external links
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    shell.openExternal(url);
+    return { action: 'deny' };
+  });
+
+  // Handle close
+  mainWindow.on('close', (event) => {
+    if (!isQuitting && process.platform === 'darwin') {
+      event.preventDefault();
+      mainWindow?.hide();
+    }
+  });
+
+  mainWindow.on('closed', () => {
+    mainWindow = null;
+  });
+
+  // Create menu
+  createMenu();
+}
+
+function createMenu(): void {
+  const template: Electron.MenuItemConstructorOptions[] = [
+    {
+      label: 'File',
+      submenu: [
+        {
+          label: 'New Citation',
+          accelerator: 'CmdOrCtrl+N',
+          click: () => {
+            mainWindow?.webContents.send('navigate', '/cite');
+          },
+        },
+        {
+          label: 'New List',
+          accelerator: 'CmdOrCtrl+Shift+N',
+          click: () => {
+            mainWindow?.webContents.send('create-list');
+          },
+        },
+        { type: 'separator' },
+        {
+          label: 'Import...',
+          accelerator: 'CmdOrCtrl+I',
+          click: () => {
+            mainWindow?.webContents.send('import');
+          },
+        },
+        {
+          label: 'Export...',
+          accelerator: 'CmdOrCtrl+E',
+          click: () => {
+            mainWindow?.webContents.send('export');
+          },
+        },
+        { type: 'separator' },
+        process.platform === 'darwin'
+          ? { role: 'close' }
+          : { role: 'quit' },
+      ],
+    },
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { role: 'selectAll' },
+      ],
+    },
+    {
+      label: 'View',
+      submenu: [
+        { role: 'reload' },
+        { role: 'forceReload' },
+        { type: 'separator' },
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
+        ...(isDev
+          ? [
+              { type: 'separator' as const },
+              { role: 'toggleDevTools' as const },
+            ]
+          : []),
+      ],
+    },
+    {
+      label: 'Go',
+      submenu: [
+        {
+          label: 'Home',
+          accelerator: 'CmdOrCtrl+H',
+          click: () => {
+            mainWindow?.webContents.send('navigate', '/');
+          },
+        },
+        {
+          label: 'Cite',
+          accelerator: 'CmdOrCtrl+1',
+          click: () => {
+            mainWindow?.webContents.send('navigate', '/cite');
+          },
+        },
+        {
+          label: 'My Lists',
+          accelerator: 'CmdOrCtrl+2',
+          click: () => {
+            mainWindow?.webContents.send('navigate', '/lists');
+          },
+        },
+        {
+          label: 'Projects',
+          accelerator: 'CmdOrCtrl+3',
+          click: () => {
+            mainWindow?.webContents.send('navigate', '/projects');
+          },
+        },
+      ],
+    },
+    {
+      label: 'Window',
+      submenu: [
+        { role: 'minimize' },
+        { role: 'zoom' },
+        ...(process.platform === 'darwin'
+          ? [
+              { type: 'separator' as const },
+              { role: 'front' as const },
+            ]
+          : []),
+      ],
+    },
+    {
+      label: 'Help',
+      submenu: [
+        {
+          label: 'Documentation',
+          click: () => {
+            shell.openExternal('https://github.com/opencitation/opencitation#readme');
+          },
+        },
+        {
+          label: 'Report Issue',
+          click: () => {
+            shell.openExternal('https://github.com/opencitation/opencitation/issues');
+          },
+        },
+        { type: 'separator' },
+        {
+          label: 'About OpenCitation',
+          click: () => {
+            mainWindow?.webContents.send('show-about');
+          },
+        },
+      ],
+    },
+  ];
+
+  // macOS app menu
+  if (process.platform === 'darwin') {
+    template.unshift({
+      label: app.name,
+      submenu: [
+        { role: 'about' },
+        { type: 'separator' },
+        {
+          label: 'Preferences...',
+          accelerator: 'CmdOrCtrl+,',
+          click: () => {
+            mainWindow?.webContents.send('navigate', '/settings');
+          },
+        },
+        { type: 'separator' },
+        { role: 'services' },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideOthers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' },
+      ],
+    });
+  }
+
+  const menu = Menu.buildFromTemplate(template);
+  Menu.setApplicationMenu(menu);
+}
+
+// IPC Handlers
+function setupIPC(): void {
+  // Get system theme
+  ipcMain.handle('get-theme', () => {
+    return nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+  });
+
+  // Set native theme
+  ipcMain.on('set-theme', (_, theme: 'light' | 'dark' | 'system') => {
+    nativeTheme.themeSource = theme;
+  });
+
+  // Show notification
+  ipcMain.on('show-notification', (_, { title, body }) => {
+    if (Notification.isSupported()) {
+      new Notification({ title, body, icon: path.join(__dirname, '../public/icon.png') }).show();
+    }
+  });
+
+  // Get app info
+  ipcMain.handle('get-app-info', () => {
+    return {
+      name: app.name,
+      version: app.getVersion(),
+      platform: process.platform,
+      arch: process.arch,
+      electron: process.versions.electron,
+      chrome: process.versions.chrome,
+      node: process.versions.node,
+    };
+  });
+
+  // Get online status
+  ipcMain.handle('get-online-status', () => {
+    return require('electron').net.isOnline();
+  });
+
+  // Check for updates (placeholder)
+  ipcMain.handle('check-for-updates', async () => {
+    // Implement auto-updater logic here
+    return { updateAvailable: false };
+  });
+
+  // Open external link
+  ipcMain.on('open-external', (_, url: string) => {
+    shell.openExternal(url);
+  });
+
+  // Minimize window
+  ipcMain.on('minimize-window', () => {
+    mainWindow?.minimize();
+  });
+
+  // Maximize window
+  ipcMain.on('maximize-window', () => {
+    if (mainWindow?.isMaximized()) {
+      mainWindow.unmaximize();
+    } else {
+      mainWindow?.maximize();
+    }
+  });
+
+  // Close window
+  ipcMain.on('close-window', () => {
+    mainWindow?.close();
+  });
+
+  // Is window maximized
+  ipcMain.handle('is-maximized', () => {
+    return mainWindow?.isMaximized() ?? false;
+  });
+}
+
+// App lifecycle
+app.on('ready', () => {
+  setupIPC();
+  createWindow();
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+app.on('activate', () => {
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createWindow();
+  } else {
+    mainWindow?.show();
+  }
+});
+
+app.on('before-quit', () => {
+  isQuitting = true;
+});
+
+// Handle deep links (e.g., opencitation://share/xyz)
+app.setAsDefaultProtocolClient('opencitation');
+
+app.on('open-url', (event, url) => {
+  event.preventDefault();
+  if (mainWindow) {
+    mainWindow.webContents.send('deep-link', url);
+    mainWindow.show();
+  }
+});
+
+// Security: Disable navigation to external sites
+app.on('web-contents-created', (_, contents) => {
+  contents.on('will-navigate', (event, navigationUrl) => {
+    const parsedUrl = new URL(navigationUrl);
+    if (
+      parsedUrl.origin !== `http://localhost:${PORT}` &&
+      parsedUrl.protocol !== 'file:'
+    ) {
+      event.preventDefault();
+      shell.openExternal(navigationUrl);
+    }
+  });
+});

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,0 +1,143 @@
+/**
+ * OpenCitation Electron Preload Script
+ * Exposes secure APIs to the renderer process
+ */
+
+import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
+
+// Type definitions for the exposed API
+export interface ElectronAPI {
+  // Theme
+  getTheme: () => Promise<'light' | 'dark'>;
+  setTheme: (theme: 'light' | 'dark' | 'system') => void;
+  onThemeChange: (callback: (theme: 'light' | 'dark') => void) => () => void;
+
+  // Notifications
+  showNotification: (title: string, body: string) => void;
+
+  // App info
+  getAppInfo: () => Promise<{
+    name: string;
+    version: string;
+    platform: string;
+    arch: string;
+    electron: string;
+    chrome: string;
+    node: string;
+  }>;
+
+  // Online status
+  getOnlineStatus: () => Promise<boolean>;
+
+  // Updates
+  checkForUpdates: () => Promise<{ updateAvailable: boolean }>;
+
+  // External links
+  openExternal: (url: string) => void;
+
+  // Window controls
+  minimizeWindow: () => void;
+  maximizeWindow: () => void;
+  closeWindow: () => void;
+  isMaximized: () => Promise<boolean>;
+
+  // Navigation events
+  onNavigate: (callback: (path: string) => void) => () => void;
+
+  // Deep links
+  onDeepLink: (callback: (url: string) => void) => () => void;
+
+  // App events
+  onCreateList: (callback: () => void) => () => void;
+  onImport: (callback: () => void) => () => void;
+  onExport: (callback: () => void) => () => void;
+  onShowAbout: (callback: () => void) => () => void;
+
+  // Platform check
+  isElectron: boolean;
+  platform: NodeJS.Platform;
+}
+
+// Helper to create event listener with cleanup
+function createEventListener<T>(
+  channel: string,
+  callback: (data: T) => void
+): () => void {
+  const handler = (_event: IpcRendererEvent, data: T) => callback(data);
+  ipcRenderer.on(channel, handler);
+  return () => {
+    ipcRenderer.removeListener(channel, handler);
+  };
+}
+
+// Expose secure API to renderer
+contextBridge.exposeInMainWorld('electronAPI', {
+  // Theme
+  getTheme: () => ipcRenderer.invoke('get-theme'),
+  setTheme: (theme: 'light' | 'dark' | 'system') => {
+    ipcRenderer.send('set-theme', theme);
+  },
+  onThemeChange: (callback: (theme: 'light' | 'dark') => void) => {
+    return createEventListener('theme-changed', callback);
+  },
+
+  // Notifications
+  showNotification: (title: string, body: string) => {
+    ipcRenderer.send('show-notification', { title, body });
+  },
+
+  // App info
+  getAppInfo: () => ipcRenderer.invoke('get-app-info'),
+
+  // Online status
+  getOnlineStatus: () => ipcRenderer.invoke('get-online-status'),
+
+  // Updates
+  checkForUpdates: () => ipcRenderer.invoke('check-for-updates'),
+
+  // External links
+  openExternal: (url: string) => {
+    ipcRenderer.send('open-external', url);
+  },
+
+  // Window controls
+  minimizeWindow: () => ipcRenderer.send('minimize-window'),
+  maximizeWindow: () => ipcRenderer.send('maximize-window'),
+  closeWindow: () => ipcRenderer.send('close-window'),
+  isMaximized: () => ipcRenderer.invoke('is-maximized'),
+
+  // Navigation events from menu
+  onNavigate: (callback: (path: string) => void) => {
+    return createEventListener('navigate', callback);
+  },
+
+  // Deep links
+  onDeepLink: (callback: (url: string) => void) => {
+    return createEventListener('deep-link', callback);
+  },
+
+  // App events
+  onCreateList: (callback: () => void) => {
+    return createEventListener('create-list', callback);
+  },
+  onImport: (callback: () => void) => {
+    return createEventListener('import', callback);
+  },
+  onExport: (callback: () => void) => {
+    return createEventListener('export', callback);
+  },
+  onShowAbout: (callback: () => void) => {
+    return createEventListener('show-about', callback);
+  },
+
+  // Platform check
+  isElectron: true,
+  platform: process.platform,
+} as ElectronAPI);
+
+// Expose version info for debugging
+contextBridge.exposeInMainWorld('versions', {
+  node: process.versions.node,
+  chrome: process.versions.chrome,
+  electron: process.versions.electron,
+});

--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "../dist-electron",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "moduleResolution": "node"
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "opencitation",
   "version": "0.1.0",
   "private": true,
+  "main": "dist-electron/main.js",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -9,7 +10,17 @@
     "lint": "eslint src",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "electron:dev": "concurrently \"npm run dev\" \"npm run electron:start\"",
+    "electron:start": "wait-on http://localhost:3000 && npm run electron:build-ts && electron .",
+    "electron:build-ts": "tsc -p electron/tsconfig.json",
+    "electron:build": "npm run build && npm run electron:build-ts && npm run electron:export && electron-builder",
+    "electron:build:mac": "npm run electron:build -- --mac",
+    "electron:build:win": "npm run electron:build -- --win",
+    "electron:build:linux": "npm run electron:build -- --linux",
+    "electron:export": "next build && next export -o out",
+    "pwa:build": "next build",
+    "postinstall": "electron-builder install-app-deps"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.978.0",
@@ -27,11 +38,18 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitest/ui": "^4.0.18",
+    "concurrently": "^9.1.2",
+    "electron": "^34.0.0",
+    "electron-builder": "^25.1.8",
     "eslint": "^9.0.0",
     "eslint-config-next": "^16.0.0",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "wait-on": "^8.0.2"
+  },
+  "build": {
+    "extends": "./electron-builder.json"
   }
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,27 +1,87 @@
 {
   "name": "OpenCitation",
   "short_name": "OpenCitation",
-  "description": "Free, open source citation generator. Create citations in APA, MLA, Chicago, and Harvard formats.",
+  "description": "Free, open source citation generator. Create citations in APA, MLA, Chicago, and Harvard formats. Works offline!",
   "start_url": "/",
+  "id": "/",
   "display": "standalone",
+  "display_override": ["window-controls-overlay", "standalone", "minimal-ui"],
   "background_color": "#f9f9f9",
   "theme_color": "#3366cc",
-  "orientation": "portrait-primary",
+  "orientation": "any",
   "scope": "/",
   "lang": "en",
+  "dir": "ltr",
   "categories": ["education", "productivity", "utilities"],
+  "prefer_related_applications": false,
   "icons": [
     {
       "src": "/icons/icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "/icons/icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "Create Citation",
+      "short_name": "Cite",
+      "description": "Create a new citation",
+      "url": "/cite"
+    },
+    {
+      "name": "My Lists",
+      "short_name": "Lists",
+      "description": "View your citation lists",
+      "url": "/lists"
+    },
+    {
+      "name": "Projects",
+      "short_name": "Projects",
+      "description": "Manage your projects",
+      "url": "/projects"
+    }
+  ],
+  "share_target": {
+    "action": "/cite",
+    "method": "GET",
+    "params": {
+      "url": "url",
+      "text": "text",
+      "title": "title"
+    }
+  },
+  "handle_links": "preferred",
+  "launch_handler": {
+    "client_mode": ["focus-existing", "auto"]
+  },
+  "edge_side_panel": {
+    "preferred_width": 400
+  },
+  "protocol_handlers": [
+    {
+      "protocol": "web+citation",
+      "url": "/cite?source=%s"
+    }
+  ],
+  "related_applications": [
+    {
+      "platform": "play",
+      "url": "https://play.google.com/store/apps/details?id=com.opencitation.app"
+    },
+    {
+      "platform": "itunes",
+      "url": "https://apps.apple.com/app/opencitation/id0000000000"
+    },
+    {
+      "platform": "windows",
+      "url": "https://www.microsoft.com/store/apps/opencitation"
     }
   ]
 }

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,328 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="theme-color" content="#3366cc">
+  <title>Offline - OpenCitation</title>
+  <link rel="icon" href="/favicon.ico">
+  <link rel="apple-touch-icon" href="/apple-icon.png">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      background-color: #f9f9f9;
+      color: #202122;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* Wikipedia 2005 style header */
+    .header {
+      background: linear-gradient(to bottom, #ffffff 0%, #f6f6f6 100%);
+      border-bottom: 1px solid #a7d7f9;
+      padding: 12px 24px;
+    }
+
+    .header-content {
+      max-width: 960px;
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .logo {
+      font-size: 24px;
+      font-weight: bold;
+      color: #3366cc;
+      text-decoration: none;
+    }
+
+    .logo-subtitle {
+      font-size: 12px;
+      color: #72777d;
+      margin-left: 8px;
+    }
+
+    /* Main content */
+    .main {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 48px 24px;
+      text-align: center;
+    }
+
+    .offline-icon {
+      width: 120px;
+      height: 120px;
+      margin-bottom: 24px;
+    }
+
+    .offline-icon svg {
+      width: 100%;
+      height: 100%;
+    }
+
+    h1 {
+      font-size: 28px;
+      font-weight: 500;
+      color: #202122;
+      margin-bottom: 16px;
+    }
+
+    .description {
+      font-size: 16px;
+      color: #54595d;
+      max-width: 480px;
+      line-height: 1.6;
+      margin-bottom: 32px;
+    }
+
+    .status-card {
+      background: #fff;
+      border: 1px solid #c8ccd1;
+      border-radius: 4px;
+      padding: 24px;
+      max-width: 400px;
+      width: 100%;
+      margin-bottom: 24px;
+    }
+
+    .status-item {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 12px 0;
+      border-bottom: 1px solid #eaecf0;
+    }
+
+    .status-item:last-child {
+      border-bottom: none;
+    }
+
+    .status-icon {
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .status-icon.warning {
+      background: #fc3;
+      color: #000;
+    }
+
+    .status-icon.info {
+      background: #3366cc;
+      color: #fff;
+    }
+
+    .status-text {
+      flex: 1;
+      text-align: left;
+      font-size: 14px;
+    }
+
+    .retry-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 24px;
+      background: #3366cc;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+
+    .retry-btn:hover {
+      background: #2a4b8d;
+    }
+
+    .retry-btn:active {
+      background: #1a3668;
+    }
+
+    .secondary-link {
+      color: #3366cc;
+      text-decoration: none;
+      font-size: 14px;
+      margin-top: 16px;
+    }
+
+    .secondary-link:hover {
+      text-decoration: underline;
+    }
+
+    /* Footer */
+    .footer {
+      background: #fff;
+      border-top: 1px solid #c8ccd1;
+      padding: 16px 24px;
+      text-align: center;
+      font-size: 12px;
+      color: #72777d;
+    }
+
+    /* Animation */
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.5; }
+    }
+
+    .pulsing {
+      animation: pulse 2s infinite;
+    }
+
+    /* Pending sync indicator */
+    .pending-sync {
+      background: #fef6e7;
+      border: 1px solid #fc3;
+      border-radius: 4px;
+      padding: 16px;
+      margin-bottom: 24px;
+      max-width: 400px;
+      width: 100%;
+    }
+
+    .pending-sync-title {
+      font-weight: 600;
+      color: #7f4f24;
+      margin-bottom: 8px;
+    }
+
+    .pending-sync-text {
+      font-size: 14px;
+      color: #54595d;
+    }
+
+    #pending-count {
+      font-weight: 600;
+      color: #3366cc;
+    }
+  </style>
+</head>
+<body>
+  <header class="header">
+    <div class="header-content">
+      <a href="/" class="logo">OpenCitation</a>
+      <span class="logo-subtitle">The Free Citation Generator</span>
+    </div>
+  </header>
+
+  <main class="main">
+    <div class="offline-icon">
+      <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M2 12C2 12 5 5 12 5C19 5 22 12 22 12C22 12 19 19 12 19C5 19 2 12 2 12Z" stroke="#c8ccd1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="12" cy="12" r="3" stroke="#c8ccd1" stroke-width="2"/>
+        <line x1="3" y1="21" x2="21" y2="3" stroke="#fc3" stroke-width="2" stroke-linecap="round"/>
+      </svg>
+    </div>
+
+    <h1>You're offline</h1>
+    <p class="description">
+      It looks like you've lost your internet connection.
+      Don't worry - your work is saved locally and will sync when you're back online.
+    </p>
+
+    <div class="pending-sync" id="pending-sync" style="display: none;">
+      <div class="pending-sync-title">Pending changes</div>
+      <div class="pending-sync-text">
+        You have <span id="pending-count">0</span> citation(s) waiting to sync when you reconnect.
+      </div>
+    </div>
+
+    <div class="status-card">
+      <div class="status-item">
+        <div class="status-icon warning">!</div>
+        <div class="status-text">No internet connection detected</div>
+      </div>
+      <div class="status-item">
+        <div class="status-icon info">i</div>
+        <div class="status-text">Your citations are saved locally</div>
+      </div>
+      <div class="status-item">
+        <div class="status-icon info">i</div>
+        <div class="status-text">Changes will auto-sync when online</div>
+      </div>
+    </div>
+
+    <button class="retry-btn" onclick="window.location.reload()">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M23 4V10H17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M1 20V14H7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M3.51 9C4.01717 7.56678 4.87913 6.28531 6.01547 5.27542C7.1518 4.26553 8.52547 3.55976 10.0083 3.22426C11.4911 2.88875 13.0348 2.93434 14.4952 3.35677C15.9556 3.77921 17.2853 4.56471 18.36 5.64L23 10M1 14L5.64 18.36C6.71475 19.4353 8.04437 20.2208 9.50481 20.6432C10.9652 21.0657 12.5089 21.1112 13.9917 20.7757C15.4745 20.4402 16.8482 19.7345 17.9845 18.7246C19.1209 17.7147 19.9828 16.4332 20.49 15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      Try again
+    </button>
+
+    <a href="/" class="secondary-link">Go to homepage</a>
+  </main>
+
+  <footer class="footer">
+    OpenCitation - Free, open source citation generator
+  </footer>
+
+  <script>
+    // Check for pending items in IndexedDB
+    async function checkPendingSync() {
+      try {
+        const dbRequest = indexedDB.open('opencitation-offline', 1);
+
+        dbRequest.onsuccess = function(event) {
+          const db = event.target.result;
+
+          if (!db.objectStoreNames.contains('sync_queue')) {
+            return;
+          }
+
+          const transaction = db.transaction(['sync_queue'], 'readonly');
+          const store = transaction.objectStore('sync_queue');
+          const countRequest = store.count();
+
+          countRequest.onsuccess = function() {
+            const count = countRequest.result;
+            if (count > 0) {
+              document.getElementById('pending-sync').style.display = 'block';
+              document.getElementById('pending-count').textContent = count;
+            }
+          };
+        };
+      } catch (e) {
+        console.log('Could not check pending sync');
+      }
+    }
+
+    // Check online status
+    function checkOnline() {
+      if (navigator.onLine) {
+        window.location.reload();
+      }
+    }
+
+    // Listen for online event
+    window.addEventListener('online', checkOnline);
+
+    // Check pending on load
+    checkPendingSync();
+
+    // Periodically check if we're back online
+    setInterval(checkOnline, 5000);
+  </script>
+</body>
+</html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,406 @@
+/**
+ * OpenCitation Service Worker
+ * Handles offline caching, background sync, and PWA functionality
+ */
+
+const CACHE_NAME = 'opencitation-v1';
+const RUNTIME_CACHE = 'opencitation-runtime-v1';
+const API_CACHE = 'opencitation-api-v1';
+
+// Assets to cache on install (App Shell)
+const PRECACHE_ASSETS = [
+  '/',
+  '/cite',
+  '/lists',
+  '/projects',
+  '/manifest.json',
+  '/icons/icon-192.png',
+  '/icons/icon-512.png',
+  '/icon.png',
+  '/apple-icon.png',
+  '/favicon.ico',
+  '/offline.html',
+];
+
+// API routes that can be cached
+const CACHEABLE_API_ROUTES = [
+  '/api/lookup/url',
+  '/api/lookup/doi',
+  '/api/lookup/isbn',
+];
+
+// Routes that should always be network-first
+const NETWORK_FIRST_ROUTES = [
+  '/api/lists',
+  '/api/projects',
+  '/api/share',
+  '/api/stats',
+];
+
+// Install event - precache app shell
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then((cache) => {
+        console.log('[SW] Precaching app shell');
+        return cache.addAll(PRECACHE_ASSETS);
+      })
+      .then(() => self.skipWaiting())
+      .catch((err) => {
+        console.error('[SW] Precache failed:', err);
+      })
+  );
+});
+
+// Activate event - clean up old caches
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    Promise.all([
+      caches.keys().then((cacheNames) => {
+        return Promise.all(
+          cacheNames
+            .filter((name) => {
+              return name.startsWith('opencitation-') &&
+                name !== CACHE_NAME &&
+                name !== RUNTIME_CACHE &&
+                name !== API_CACHE;
+            })
+            .map((name) => {
+              console.log('[SW] Deleting old cache:', name);
+              return caches.delete(name);
+            })
+        );
+      }),
+      self.clients.claim(),
+    ])
+  );
+});
+
+// Fetch event - handle requests with appropriate strategy
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Skip non-GET requests for caching
+  if (request.method !== 'GET') {
+    return;
+  }
+
+  // Skip Chrome extension requests
+  if (url.protocol === 'chrome-extension:') {
+    return;
+  }
+
+  // Skip Clerk auth requests
+  if (url.hostname.includes('clerk.') || url.pathname.includes('clerk')) {
+    return;
+  }
+
+  // Handle API requests
+  if (url.pathname.startsWith('/api/')) {
+    event.respondWith(handleApiRequest(request, url));
+    return;
+  }
+
+  // Handle navigation requests (HTML pages)
+  if (request.mode === 'navigate') {
+    event.respondWith(handleNavigationRequest(request));
+    return;
+  }
+
+  // Handle static assets with cache-first
+  event.respondWith(handleStaticAssetRequest(request));
+});
+
+// Navigation requests - network first with offline fallback
+async function handleNavigationRequest(request) {
+  try {
+    // Try network first
+    const networkResponse = await fetch(request);
+
+    // Cache successful responses
+    if (networkResponse.ok) {
+      const cache = await caches.open(RUNTIME_CACHE);
+      cache.put(request, networkResponse.clone());
+    }
+
+    return networkResponse;
+  } catch (error) {
+    // Try cache
+    const cachedResponse = await caches.match(request);
+    if (cachedResponse) {
+      return cachedResponse;
+    }
+
+    // Return offline page
+    const offlinePage = await caches.match('/offline.html');
+    if (offlinePage) {
+      return offlinePage;
+    }
+
+    // Last resort - return a basic offline response
+    return new Response(
+      '<!DOCTYPE html><html><head><title>Offline</title></head><body><h1>You are offline</h1><p>OpenCitation is not available offline. Please check your connection.</p></body></html>',
+      {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      }
+    );
+  }
+}
+
+// API requests - different strategies based on route
+async function handleApiRequest(request, url) {
+  const isLookupApi = CACHEABLE_API_ROUTES.some((route) =>
+    url.pathname.startsWith(route)
+  );
+  const isNetworkFirst = NETWORK_FIRST_ROUTES.some((route) =>
+    url.pathname.startsWith(route)
+  );
+
+  if (isLookupApi) {
+    // Cache-first for lookup APIs (data doesn't change often)
+    return handleCacheFirstRequest(request, API_CACHE);
+  }
+
+  if (isNetworkFirst) {
+    // Network-first for user data APIs
+    return handleNetworkFirstRequest(request, API_CACHE);
+  }
+
+  // Default to network-only for other APIs
+  return fetch(request);
+}
+
+// Cache-first strategy
+async function handleCacheFirstRequest(request, cacheName) {
+  const cachedResponse = await caches.match(request);
+  if (cachedResponse) {
+    // Update cache in background
+    fetch(request)
+      .then((response) => {
+        if (response.ok) {
+          caches.open(cacheName).then((cache) => {
+            cache.put(request, response);
+          });
+        }
+      })
+      .catch(() => {});
+
+    return cachedResponse;
+  }
+
+  try {
+    const networkResponse = await fetch(request);
+
+    if (networkResponse.ok) {
+      const cache = await caches.open(cacheName);
+      cache.put(request, networkResponse.clone());
+    }
+
+    return networkResponse;
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ error: 'Offline - data not cached' }),
+      {
+        status: 503,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  }
+}
+
+// Network-first strategy
+async function handleNetworkFirstRequest(request, cacheName) {
+  try {
+    const networkResponse = await fetch(request);
+
+    if (networkResponse.ok) {
+      const cache = await caches.open(cacheName);
+      cache.put(request, networkResponse.clone());
+    }
+
+    return networkResponse;
+  } catch (error) {
+    const cachedResponse = await caches.match(request);
+    if (cachedResponse) {
+      return cachedResponse;
+    }
+
+    return new Response(
+      JSON.stringify({ error: 'Offline - please try again when connected' }),
+      {
+        status: 503,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  }
+}
+
+// Static asset requests - cache-first with network fallback
+async function handleStaticAssetRequest(request) {
+  const cachedResponse = await caches.match(request);
+  if (cachedResponse) {
+    return cachedResponse;
+  }
+
+  try {
+    const networkResponse = await fetch(request);
+
+    if (networkResponse.ok) {
+      const cache = await caches.open(RUNTIME_CACHE);
+      cache.put(request, networkResponse.clone());
+    }
+
+    return networkResponse;
+  } catch (error) {
+    // Return a placeholder for images
+    if (request.destination === 'image') {
+      return new Response(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect fill="#ccc" width="100" height="100"/><text x="50" y="50" text-anchor="middle" fill="#666">Offline</text></svg>',
+        {
+          headers: { 'Content-Type': 'image/svg+xml' },
+        }
+      );
+    }
+
+    return new Response('', { status: 404 });
+  }
+}
+
+// Background sync for offline operations
+self.addEventListener('sync', (event) => {
+  if (event.tag === 'sync-citations') {
+    event.waitUntil(syncCitations());
+  }
+});
+
+async function syncCitations() {
+  // Notify clients to trigger sync
+  const clients = await self.clients.matchAll();
+  clients.forEach((client) => {
+    client.postMessage({
+      type: 'SYNC_TRIGGERED',
+      timestamp: new Date().toISOString(),
+    });
+  });
+}
+
+// Handle messages from clients
+self.addEventListener('message', (event) => {
+  const { type, payload } = event.data || {};
+
+  switch (type) {
+    case 'SKIP_WAITING':
+      self.skipWaiting();
+      break;
+
+    case 'CLEAR_CACHE':
+      event.waitUntil(
+        Promise.all([
+          caches.delete(CACHE_NAME),
+          caches.delete(RUNTIME_CACHE),
+          caches.delete(API_CACHE),
+        ]).then(() => {
+          event.ports[0]?.postMessage({ success: true });
+        })
+      );
+      break;
+
+    case 'GET_CACHE_SIZE':
+      event.waitUntil(
+        getCacheSize().then((size) => {
+          event.ports[0]?.postMessage({ size });
+        })
+      );
+      break;
+
+    case 'PRECACHE_PAGE':
+      if (payload?.url) {
+        event.waitUntil(
+          caches.open(RUNTIME_CACHE).then((cache) => {
+            return cache.add(payload.url);
+          })
+        );
+      }
+      break;
+
+    default:
+      break;
+  }
+});
+
+// Calculate total cache size
+async function getCacheSize() {
+  const cacheNames = await caches.keys();
+  let totalSize = 0;
+
+  for (const name of cacheNames) {
+    if (!name.startsWith('opencitation-')) continue;
+
+    const cache = await caches.open(name);
+    const keys = await cache.keys();
+
+    for (const request of keys) {
+      const response = await cache.match(request);
+      if (response) {
+        const blob = await response.blob();
+        totalSize += blob.size;
+      }
+    }
+  }
+
+  return totalSize;
+}
+
+// Push notification handling
+self.addEventListener('push', (event) => {
+  const data = event.data?.json() || {};
+
+  const options = {
+    body: data.body || 'New update from OpenCitation',
+    icon: '/icons/icon-192.png',
+    badge: '/icons/icon-192.png',
+    vibrate: [100, 50, 100],
+    data: {
+      url: data.url || '/',
+    },
+    actions: [
+      { action: 'open', title: 'Open' },
+      { action: 'dismiss', title: 'Dismiss' },
+    ],
+  };
+
+  event.waitUntil(
+    self.registration.showNotification(
+      data.title || 'OpenCitation',
+      options
+    )
+  );
+});
+
+// Notification click handling
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+
+  if (event.action === 'dismiss') {
+    return;
+  }
+
+  const urlToOpen = event.notification.data?.url || '/';
+
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window' }).then((clientList) => {
+      // Check if there's already a window open
+      for (const client of clientList) {
+        if (client.url === urlToOpen && 'focus' in client) {
+          return client.focus();
+        }
+      }
+      // Open a new window
+      return self.clients.openWindow(urlToOpen);
+    })
+  );
+});
+
+console.log('[SW] Service Worker loaded');

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { ClerkProvider } from "@clerk/nextjs";
+import { PWAProvider } from "@/components/pwa/pwa-provider";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -10,6 +11,15 @@ export const metadata: Metadata = {
   creator: "OpenCitation",
   publisher: "OpenCitation",
   metadataBase: new URL("https://opencitation.vercel.app"),
+  applicationName: "OpenCitation",
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "default",
+    title: "OpenCitation",
+  },
+  formatDetection: {
+    telephone: false,
+  },
   openGraph: {
     title: "OpenCitation - Free Citation Generator",
     description: "Generate, organize, and share citations in APA, MLA, Chicago, and Harvard formats. Free, open source, no account required.",
@@ -39,6 +49,15 @@ export const metadata: Metadata = {
   },
 };
 
+export const viewport: Viewport = {
+  themeColor: "#3366cc",
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 5,
+  userScalable: true,
+  viewportFit: "cover",
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -48,11 +67,18 @@ export default function RootLayout({
     <ClerkProvider>
       <html lang="en">
         <head>
-          <meta name="theme-color" content="#3366cc" />
+          <meta name="mobile-web-app-capable" content="yes" />
+          <meta name="apple-mobile-web-app-capable" content="yes" />
+          <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+          <meta name="apple-mobile-web-app-title" content="OpenCitation" />
           <link rel="manifest" href="/manifest.json" />
+          <link rel="apple-touch-icon" href="/apple-icon.png" />
+          <link rel="apple-touch-startup-image" href="/icons/icon-512.png" />
         </head>
         <body className="antialiased">
-          {children}
+          <PWAProvider>
+            {children}
+          </PWAProvider>
         </body>
       </html>
     </ClerkProvider>

--- a/src/components/pwa/index.ts
+++ b/src/components/pwa/index.ts
@@ -1,0 +1,15 @@
+/**
+ * PWA Components Export
+ */
+
+export { OfflineIndicator, default as OfflineIndicatorDefault } from './offline-indicator';
+export { PWAProvider, default as PWAProviderDefault } from './pwa-provider';
+
+export {
+  useSyncState,
+  usePWA,
+  useOnlineStatus,
+  useOfflineLists,
+  useOfflineCitations,
+  useOfflineProjects,
+} from './use-offline';

--- a/src/components/pwa/index.ts
+++ b/src/components/pwa/index.ts
@@ -4,6 +4,7 @@
 
 export { OfflineIndicator, default as OfflineIndicatorDefault } from './offline-indicator';
 export { PWAProvider, default as PWAProviderDefault } from './pwa-provider';
+export { SafariInstallBanner, default as SafariInstallBannerDefault } from './safari-install-banner';
 
 export {
   useSyncState,

--- a/src/components/pwa/offline-indicator.tsx
+++ b/src/components/pwa/offline-indicator.tsx
@@ -1,0 +1,310 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { syncManager, SyncManagerState } from '@/lib/pwa/sync-manager';
+import { pwaManager, PWAState } from '@/lib/pwa/pwa-utils';
+
+interface OfflineIndicatorProps {
+  position?: 'top' | 'bottom';
+  showSyncStatus?: boolean;
+}
+
+export function OfflineIndicator({
+  position = 'bottom',
+  showSyncStatus = true,
+}: OfflineIndicatorProps) {
+  const [syncState, setSyncState] = useState<SyncManagerState>({
+    isOnline: true,
+    isSyncing: false,
+    pendingCount: 0,
+    lastSyncAt: null,
+    lastError: null,
+  });
+
+  const [pwaState, setPwaState] = useState<PWAState>({
+    isInstalled: false,
+    isInstallable: false,
+    isOffline: false,
+    isUpdateAvailable: false,
+    swRegistration: null,
+  });
+
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [showUpdateBanner, setShowUpdateBanner] = useState(false);
+
+  useEffect(() => {
+    // Initialize managers
+    syncManager.init();
+    pwaManager.init();
+
+    // Subscribe to state changes
+    const unsubscribeSync = syncManager.subscribe(setSyncState);
+    const unsubscribePwa = pwaManager.subscribe((state) => {
+      setPwaState(state);
+      if (state.isUpdateAvailable) {
+        setShowUpdateBanner(true);
+      }
+    });
+
+    return () => {
+      unsubscribeSync();
+      unsubscribePwa();
+    };
+  }, []);
+
+  const handleSync = useCallback(async () => {
+    await syncManager.sync();
+  }, []);
+
+  const handleUpdate = useCallback(async () => {
+    await pwaManager.applyUpdate();
+  }, []);
+
+  const handleInstall = useCallback(async () => {
+    await pwaManager.promptInstall();
+  }, []);
+
+  // Don't show anything if online with no pending items
+  if (syncState.isOnline && syncState.pendingCount === 0 && !showUpdateBanner && !pwaState.isInstallable) {
+    return null;
+  }
+
+  const positionClasses = position === 'top' ? 'top-0' : 'bottom-0';
+
+  return (
+    <>
+      {/* Offline/Sync Status Bar */}
+      {(!syncState.isOnline || syncState.pendingCount > 0) && (
+        <div
+          className={`fixed ${positionClasses} left-0 right-0 z-50 transition-all duration-300`}
+        >
+          <div
+            className={`
+              ${!syncState.isOnline ? 'bg-amber-500' : 'bg-blue-500'}
+              text-white px-4 py-2 shadow-lg
+            `}
+          >
+            <div className="max-w-4xl mx-auto flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                {/* Status Icon */}
+                {!syncState.isOnline ? (
+                  <svg
+                    className="w-5 h-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M18.364 5.636a9 9 0 010 12.728m0 0l-2.829-2.829m2.829 2.829L21 21M15.536 8.464a5 5 0 010 7.072m0 0l-2.829-2.829m-4.243 2.829a4.978 4.978 0 01-1.414-2.83m-1.414 5.658a9 9 0 01-2.167-9.238m7.824 2.167a1 1 0 111.414 1.414m-1.414-1.414L3 3m8.293 8.293l1.414 1.414"
+                    />
+                  </svg>
+                ) : syncState.isSyncing ? (
+                  <svg
+                    className="w-5 h-5 animate-spin"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    />
+                  </svg>
+                ) : (
+                  <svg
+                    className="w-5 h-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                    />
+                  </svg>
+                )}
+
+                {/* Status Text */}
+                <div className="flex flex-col">
+                  <span className="text-sm font-medium">
+                    {!syncState.isOnline
+                      ? "You're offline"
+                      : syncState.isSyncing
+                        ? 'Syncing...'
+                        : `${syncState.pendingCount} item${syncState.pendingCount !== 1 ? 's' : ''} pending`}
+                  </span>
+                  {showSyncStatus && syncState.pendingCount > 0 && !syncState.isSyncing && (
+                    <span className="text-xs opacity-80">
+                      {!syncState.isOnline
+                        ? 'Will sync when back online'
+                        : 'Click to sync now'}
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              {/* Action Buttons */}
+              <div className="flex items-center gap-2">
+                {syncState.isOnline && syncState.pendingCount > 0 && !syncState.isSyncing && (
+                  <button
+                    onClick={handleSync}
+                    className="px-3 py-1 text-sm bg-white/20 hover:bg-white/30 rounded transition-colors"
+                  >
+                    Sync now
+                  </button>
+                )}
+
+                <button
+                  onClick={() => setIsExpanded(!isExpanded)}
+                  className="p-1 hover:bg-white/20 rounded transition-colors"
+                  aria-label={isExpanded ? 'Collapse details' : 'Expand details'}
+                >
+                  <svg
+                    className={`w-4 h-4 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 9l-7 7-7-7"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+
+            {/* Expanded Details */}
+            {isExpanded && (
+              <div className="max-w-4xl mx-auto mt-3 pt-3 border-t border-white/20">
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+                  <div>
+                    <div className="text-xs opacity-70">Status</div>
+                    <div className="font-medium">
+                      {syncState.isOnline ? 'Online' : 'Offline'}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-xs opacity-70">Pending</div>
+                    <div className="font-medium">{syncState.pendingCount} items</div>
+                  </div>
+                  <div>
+                    <div className="text-xs opacity-70">Last Sync</div>
+                    <div className="font-medium">
+                      {syncState.lastSyncAt
+                        ? new Date(syncState.lastSyncAt).toLocaleTimeString()
+                        : 'Never'}
+                    </div>
+                  </div>
+                  {syncState.lastError && (
+                    <div>
+                      <div className="text-xs opacity-70">Last Error</div>
+                      <div className="font-medium text-red-200 truncate">
+                        {syncState.lastError}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Update Available Banner */}
+      {showUpdateBanner && pwaState.isUpdateAvailable && (
+        <div className="fixed top-0 left-0 right-0 z-50 bg-green-600 text-white px-4 py-2 shadow-lg">
+          <div className="max-w-4xl mx-auto flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"
+                />
+              </svg>
+              <span className="text-sm font-medium">
+                A new version of OpenCitation is available!
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={handleUpdate}
+                className="px-3 py-1 text-sm bg-white text-green-600 font-medium rounded hover:bg-green-50 transition-colors"
+              >
+                Update now
+              </button>
+              <button
+                onClick={() => setShowUpdateBanner(false)}
+                className="p-1 hover:bg-white/20 rounded transition-colors"
+                aria-label="Dismiss"
+              >
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Install Prompt (for non-installed PWA) */}
+      {pwaState.isInstallable && !pwaState.isInstalled && (
+        <div className="fixed bottom-4 right-4 z-40">
+          <button
+            onClick={handleInstall}
+            className="flex items-center gap-2 px-4 py-3 bg-[#3366cc] text-white rounded-lg shadow-lg hover:bg-[#2a4b8d] transition-colors"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+              />
+            </svg>
+            <span className="font-medium">Install App</span>
+          </button>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default OfflineIndicator;

--- a/src/components/pwa/pwa-provider.tsx
+++ b/src/components/pwa/pwa-provider.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect, ReactNode } from 'react';
+import { pwaManager } from '@/lib/pwa/pwa-utils';
+import { syncManager } from '@/lib/pwa/sync-manager';
+import { OfflineIndicator } from './offline-indicator';
+
+interface PWAProviderProps {
+  children: ReactNode;
+}
+
+export function PWAProvider({ children }: PWAProviderProps) {
+  useEffect(() => {
+    // Initialize PWA and sync managers
+    pwaManager.init();
+    syncManager.init();
+
+    // Handle Electron navigation events
+    if (typeof window !== 'undefined' && (window as Window & { electronAPI?: { onNavigate?: (cb: (path: string) => void) => () => void } }).electronAPI?.onNavigate) {
+      const cleanup = (window as Window & { electronAPI: { onNavigate: (cb: (path: string) => void) => () => void } }).electronAPI.onNavigate((path: string) => {
+        window.location.href = path;
+      });
+      return cleanup;
+    }
+  }, []);
+
+  return (
+    <>
+      {children}
+      <OfflineIndicator position="bottom" showSyncStatus />
+    </>
+  );
+}
+
+export default PWAProvider;

--- a/src/components/pwa/pwa-provider.tsx
+++ b/src/components/pwa/pwa-provider.tsx
@@ -4,6 +4,7 @@ import { useEffect, ReactNode } from 'react';
 import { pwaManager } from '@/lib/pwa/pwa-utils';
 import { syncManager } from '@/lib/pwa/sync-manager';
 import { OfflineIndicator } from './offline-indicator';
+import { SafariInstallBanner } from './safari-install-banner';
 
 interface PWAProviderProps {
   children: ReactNode;
@@ -28,6 +29,7 @@ export function PWAProvider({ children }: PWAProviderProps) {
     <>
       {children}
       <OfflineIndicator position="bottom" showSyncStatus />
+      <SafariInstallBanner />
     </>
   );
 }

--- a/src/components/pwa/safari-install-banner.tsx
+++ b/src/components/pwa/safari-install-banner.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export function SafariInstallBanner() {
+  const [showBanner, setShowBanner] = useState(false);
+  const [isIOS, setIsIOS] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const wasDismissed = localStorage.getItem('safari-install-dismissed');
+    if (wasDismissed) return;
+
+    const ua = navigator.userAgent.toLowerCase();
+    const isSafari = /safari/.test(ua) && !/chrome|chromium|android|crios|fxios|edgios/.test(ua);
+    const isIOSDevice = /iphone|ipad|ipod/.test(ua) ||
+      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    const isStandalone = window.matchMedia('(display-mode: standalone)').matches ||
+      (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
+
+    setIsIOS(isIOSDevice);
+
+    if (isSafari && !isStandalone) {
+      setTimeout(() => setShowBanner(true), 1500);
+    }
+  }, []);
+
+  const handleDismiss = () => {
+    setShowBanner(false);
+    localStorage.setItem('safari-install-dismissed', 'true');
+  };
+
+  if (!showBanner) return null;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 safe-area-bottom">
+      <div className="bg-[#f2f2f7] border-t border-[#c6c6c8] px-4 py-3">
+        <div className="max-w-lg mx-auto flex items-center gap-3">
+          {/* App Icon */}
+          <div className="w-12 h-12 bg-white rounded-xl shadow-sm flex items-center justify-center flex-shrink-0">
+            <svg className="w-7 h-7 text-[#007aff]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M12 2L2 7l10 5 10-5-10-5z"/>
+              <path d="M2 17l10 5 10-5"/>
+              <path d="M2 12l10 5 10-5"/>
+            </svg>
+          </div>
+
+          {/* Text */}
+          <div className="flex-1 min-w-0">
+            <p className="text-[15px] font-semibold text-black">
+              Install OpenCitation
+            </p>
+            <p className="text-[13px] text-[#8e8e93]">
+              {isIOS ? (
+                <>Tap <span className="inline-block w-4 h-4 align-middle">
+                  <svg viewBox="0 0 24 24" fill="currentColor" className="text-[#007aff]">
+                    <path d="M12 2v13m0-13l4 4m-4-4L8 6M4 14v6h16v-6"/>
+                  </svg>
+                </span> then &quot;Add to Home Screen&quot;</>
+              ) : (
+                <>File → Add to Dock</>
+              )}
+            </p>
+          </div>
+
+          {/* Close */}
+          <button
+            onClick={handleDismiss}
+            className="w-8 h-8 flex items-center justify-center text-[#8e8e93] hover:text-[#636366] flex-shrink-0"
+            aria-label="Dismiss"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SafariInstallBanner;

--- a/src/components/pwa/use-offline.ts
+++ b/src/components/pwa/use-offline.ts
@@ -1,0 +1,470 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { syncManager, SyncManagerState } from '@/lib/pwa/sync-manager';
+import { pwaManager, PWAState } from '@/lib/pwa/pwa-utils';
+import { offlineStore, OfflineList, OfflineCitation, OfflineProject } from '@/lib/pwa/offline-store';
+
+/**
+ * Hook for sync manager state
+ */
+export function useSyncState() {
+  const [state, setState] = useState<SyncManagerState>({
+    isOnline: true,
+    isSyncing: false,
+    pendingCount: 0,
+    lastSyncAt: null,
+    lastError: null,
+  });
+
+  useEffect(() => {
+    syncManager.init();
+    const unsubscribe = syncManager.subscribe(setState);
+    return unsubscribe;
+  }, []);
+
+  const sync = useCallback(() => syncManager.sync(), []);
+  const retryFailed = useCallback(() => syncManager.retryFailed(), []);
+  const clearQueue = useCallback(() => syncManager.clearQueue(), []);
+
+  return {
+    ...state,
+    sync,
+    retryFailed,
+    clearQueue,
+  };
+}
+
+/**
+ * Hook for PWA state
+ */
+export function usePWA() {
+  const [state, setState] = useState<PWAState>({
+    isInstalled: false,
+    isInstallable: false,
+    isOffline: false,
+    isUpdateAvailable: false,
+    swRegistration: null,
+  });
+
+  useEffect(() => {
+    pwaManager.init();
+    const unsubscribe = pwaManager.subscribe(setState);
+    return unsubscribe;
+  }, []);
+
+  const install = useCallback(() => pwaManager.promptInstall(), []);
+  const update = useCallback(() => pwaManager.applyUpdate(), []);
+  const clearCache = useCallback(() => pwaManager.clearCache(), []);
+  const getCacheSize = useCallback(() => pwaManager.getCacheSize(), []);
+
+  return {
+    ...state,
+    install,
+    update,
+    clearCache,
+    getCacheSize,
+  };
+}
+
+/**
+ * Hook for online status
+ */
+export function useOnlineStatus() {
+  const [isOnline, setIsOnline] = useState(
+    typeof navigator !== 'undefined' ? navigator.onLine : true
+  );
+
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  return isOnline;
+}
+
+/**
+ * Hook for offline-capable lists
+ */
+export function useOfflineLists(userId?: string) {
+  const [lists, setLists] = useState<OfflineList[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const isOnline = useOnlineStatus();
+
+  const fetchLists = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      if (isOnline) {
+        // Fetch from API
+        const response = await fetch('/api/lists');
+        if (response.ok) {
+          const data = await response.json();
+          // Save to offline store
+          await offlineStore.bulkSaveLists(data.lists);
+          setLists(data.lists);
+        } else {
+          throw new Error('Failed to fetch lists');
+        }
+      } else {
+        // Fetch from offline store
+        const offlineLists = userId
+          ? await offlineStore.getListsByUser(userId)
+          : await offlineStore.getAllLists();
+        setLists(offlineLists);
+      }
+    } catch (err) {
+      // Fallback to offline store on error
+      const offlineLists = userId
+        ? await offlineStore.getListsByUser(userId)
+        : await offlineStore.getAllLists();
+      setLists(offlineLists);
+
+      if (isOnline) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch lists');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [isOnline, userId]);
+
+  const createList = useCallback(
+    async (name: string, projectId?: string) => {
+      const now = new Date().toISOString();
+      const tempId = `temp_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+
+      const newList: OfflineList = {
+        id: tempId,
+        name,
+        projectId,
+        userId: userId || 'local',
+        createdAt: now,
+        updatedAt: now,
+        _offline: !isOnline,
+        _synced: false,
+      };
+
+      // Save locally first
+      await offlineStore.saveList(newList);
+      setLists((prev) => [...prev, newList]);
+
+      if (isOnline) {
+        try {
+          const response = await fetch('/api/lists', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name, projectId }),
+          });
+
+          if (response.ok) {
+            const data = await response.json();
+            // Update with real ID
+            await offlineStore.deleteList(tempId);
+            await offlineStore.saveList({ ...data.list, _synced: true });
+            setLists((prev) =>
+              prev.map((l) => (l.id === tempId ? { ...data.list, _synced: true } : l))
+            );
+            return data.list;
+          }
+        } catch {
+          // Queue for sync
+          await syncManager.queueCreate('list', tempId, { name, projectId });
+        }
+      } else {
+        // Queue for sync when back online
+        await syncManager.queueCreate('list', tempId, { name, projectId });
+      }
+
+      return newList;
+    },
+    [isOnline, userId]
+  );
+
+  const deleteList = useCallback(
+    async (id: string) => {
+      // Remove locally first
+      await offlineStore.deleteList(id);
+      setLists((prev) => prev.filter((l) => l.id !== id));
+
+      if (isOnline && !id.startsWith('temp_')) {
+        try {
+          await fetch(`/api/lists/${id}`, { method: 'DELETE' });
+        } catch {
+          await syncManager.queueDelete('list', id);
+        }
+      } else if (!id.startsWith('temp_')) {
+        await syncManager.queueDelete('list', id);
+      }
+    },
+    [isOnline]
+  );
+
+  useEffect(() => {
+    fetchLists();
+  }, [fetchLists]);
+
+  return {
+    lists,
+    loading,
+    error,
+    refresh: fetchLists,
+    createList,
+    deleteList,
+    isOnline,
+  };
+}
+
+/**
+ * Hook for offline-capable citations
+ */
+export function useOfflineCitations(listId: string) {
+  const [citations, setCitations] = useState<OfflineCitation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const isOnline = useOnlineStatus();
+
+  const fetchCitations = useCallback(async () => {
+    if (!listId) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      if (isOnline && !listId.startsWith('temp_')) {
+        const response = await fetch(`/api/lists/${listId}/citations`);
+        if (response.ok) {
+          const data = await response.json();
+          await offlineStore.bulkSaveCitations(data.citations);
+          setCitations(data.citations);
+        } else {
+          throw new Error('Failed to fetch citations');
+        }
+      } else {
+        const offlineCitations = await offlineStore.getCitationsByList(listId);
+        setCitations(offlineCitations);
+      }
+    } catch (err) {
+      const offlineCitations = await offlineStore.getCitationsByList(listId);
+      setCitations(offlineCitations);
+
+      if (isOnline) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch citations');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [isOnline, listId]);
+
+  const addCitation = useCallback(
+    async (citationData: Omit<OfflineCitation, 'id' | 'listId' | 'createdAt' | 'updatedAt' | '_offline' | '_synced'>) => {
+      const now = new Date().toISOString();
+      const tempId = `temp_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+
+      const newCitation: OfflineCitation = {
+        ...citationData,
+        id: tempId,
+        listId,
+        createdAt: now,
+        updatedAt: now,
+        _offline: !isOnline,
+        _synced: false,
+      };
+
+      await offlineStore.saveCitation(newCitation);
+      setCitations((prev) => [...prev, newCitation]);
+
+      if (isOnline && !listId.startsWith('temp_')) {
+        try {
+          const response = await fetch(`/api/lists/${listId}/citations`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(citationData),
+          });
+
+          if (response.ok) {
+            const data = await response.json();
+            await offlineStore.deleteCitation(tempId);
+            await offlineStore.saveCitation({ ...data.citation, _synced: true });
+            setCitations((prev) =>
+              prev.map((c) => (c.id === tempId ? { ...data.citation, _synced: true } : c))
+            );
+            return data.citation;
+          }
+        } catch {
+          await syncManager.queueCreate('citation', tempId, citationData, listId);
+        }
+      } else {
+        await syncManager.queueCreate('citation', tempId, citationData, listId);
+      }
+
+      return newCitation;
+    },
+    [isOnline, listId]
+  );
+
+  const deleteCitation = useCallback(
+    async (id: string) => {
+      await offlineStore.deleteCitation(id);
+      setCitations((prev) => prev.filter((c) => c.id !== id));
+
+      if (isOnline && !id.startsWith('temp_') && !listId.startsWith('temp_')) {
+        try {
+          await fetch(`/api/lists/${listId}/citations/${id}`, { method: 'DELETE' });
+        } catch {
+          await syncManager.queueDelete('citation', id, listId);
+        }
+      } else if (!id.startsWith('temp_')) {
+        await syncManager.queueDelete('citation', id, listId);
+      }
+    },
+    [isOnline, listId]
+  );
+
+  useEffect(() => {
+    fetchCitations();
+  }, [fetchCitations]);
+
+  return {
+    citations,
+    loading,
+    error,
+    refresh: fetchCitations,
+    addCitation,
+    deleteCitation,
+    isOnline,
+  };
+}
+
+/**
+ * Hook for offline-capable projects
+ */
+export function useOfflineProjects(userId?: string) {
+  const [projects, setProjects] = useState<OfflineProject[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const isOnline = useOnlineStatus();
+
+  const fetchProjects = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      if (isOnline) {
+        const response = await fetch('/api/projects');
+        if (response.ok) {
+          const data = await response.json();
+          await offlineStore.bulkSaveProjects(data.projects);
+          setProjects(data.projects);
+        } else {
+          throw new Error('Failed to fetch projects');
+        }
+      } else {
+        const offlineProjects = userId
+          ? await offlineStore.getProjectsByUser(userId)
+          : await offlineStore.getAllProjects();
+        setProjects(offlineProjects);
+      }
+    } catch (err) {
+      const offlineProjects = userId
+        ? await offlineStore.getProjectsByUser(userId)
+        : await offlineStore.getAllProjects();
+      setProjects(offlineProjects);
+
+      if (isOnline) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch projects');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [isOnline, userId]);
+
+  const createProject = useCallback(
+    async (name: string, description?: string) => {
+      const now = new Date().toISOString();
+      const tempId = `temp_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+
+      const newProject: OfflineProject = {
+        id: tempId,
+        name,
+        description,
+        userId: userId || 'local',
+        createdAt: now,
+        updatedAt: now,
+        _offline: !isOnline,
+        _synced: false,
+      };
+
+      await offlineStore.saveProject(newProject);
+      setProjects((prev) => [...prev, newProject]);
+
+      if (isOnline) {
+        try {
+          const response = await fetch('/api/projects', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name, description }),
+          });
+
+          if (response.ok) {
+            const data = await response.json();
+            await offlineStore.deleteProject(tempId);
+            await offlineStore.saveProject({ ...data.project, _synced: true });
+            setProjects((prev) =>
+              prev.map((p) => (p.id === tempId ? { ...data.project, _synced: true } : p))
+            );
+            return data.project;
+          }
+        } catch {
+          await syncManager.queueCreate('project', tempId, { name, description });
+        }
+      } else {
+        await syncManager.queueCreate('project', tempId, { name, description });
+      }
+
+      return newProject;
+    },
+    [isOnline, userId]
+  );
+
+  const deleteProject = useCallback(
+    async (id: string) => {
+      await offlineStore.deleteProject(id);
+      setProjects((prev) => prev.filter((p) => p.id !== id));
+
+      if (isOnline && !id.startsWith('temp_')) {
+        try {
+          await fetch(`/api/projects/${id}`, { method: 'DELETE' });
+        } catch {
+          await syncManager.queueDelete('project', id);
+        }
+      } else if (!id.startsWith('temp_')) {
+        await syncManager.queueDelete('project', id);
+      }
+    },
+    [isOnline]
+  );
+
+  useEffect(() => {
+    fetchProjects();
+  }, [fetchProjects]);
+
+  return {
+    projects,
+    loading,
+    error,
+    refresh: fetchProjects,
+    createProject,
+    deleteProject,
+    isOnline,
+  };
+}

--- a/src/lib/pwa/index.ts
+++ b/src/lib/pwa/index.ts
@@ -1,0 +1,25 @@
+/**
+ * PWA Module Exports
+ */
+
+export { offlineStore } from './offline-store';
+export type {
+  OfflineList,
+  OfflineCitation,
+  OfflineProject,
+  SyncQueueItem,
+  CacheMeta,
+} from './offline-store';
+
+export { syncManager, useSyncManager } from './sync-manager';
+export type { SyncStatus, SyncResult, SyncManagerState } from './sync-manager';
+
+export {
+  pwaManager,
+  formatBytes,
+  isPWASupported,
+  isStandalone,
+  isElectron,
+  getPlatform,
+} from './pwa-utils';
+export type { PWAState, BeforeInstallPromptEvent } from './pwa-utils';

--- a/src/lib/pwa/offline-store.ts
+++ b/src/lib/pwa/offline-store.ts
@@ -1,0 +1,419 @@
+/**
+ * IndexedDB Offline Store
+ * Client-side persistence for offline PWA functionality
+ */
+
+const DB_NAME = 'opencitation-offline';
+const DB_VERSION = 1;
+
+// Store names
+const STORES = {
+  LISTS: 'lists',
+  CITATIONS: 'citations',
+  PROJECTS: 'projects',
+  SYNC_QUEUE: 'sync_queue',
+  CACHE_META: 'cache_meta',
+} as const;
+
+export interface OfflineList {
+  id: string;
+  name: string;
+  projectId?: string;
+  userId: string;
+  createdAt: string;
+  updatedAt: string;
+  _offline?: boolean;
+  _synced?: boolean;
+}
+
+export interface OfflineCitation {
+  id: string;
+  listId: string;
+  fields: Record<string, unknown>;
+  style: string;
+  formattedText: string;
+  formattedHtml: string;
+  createdAt: string;
+  updatedAt: string;
+  _offline?: boolean;
+  _synced?: boolean;
+}
+
+export interface OfflineProject {
+  id: string;
+  name: string;
+  description?: string;
+  userId: string;
+  createdAt: string;
+  updatedAt: string;
+  _offline?: boolean;
+  _synced?: boolean;
+}
+
+export interface SyncQueueItem {
+  id: string;
+  type: 'create' | 'update' | 'delete';
+  entity: 'list' | 'citation' | 'project';
+  entityId: string;
+  parentId?: string;
+  data?: Record<string, unknown>;
+  createdAt: string;
+  retryCount: number;
+  lastError?: string;
+}
+
+export interface CacheMeta {
+  key: string;
+  lastUpdated: string;
+  expiresAt?: string;
+}
+
+class OfflineStore {
+  private db: IDBDatabase | null = null;
+  private initPromise: Promise<IDBDatabase> | null = null;
+
+  async init(): Promise<IDBDatabase> {
+    if (this.db) return this.db;
+    if (this.initPromise) return this.initPromise;
+
+    this.initPromise = new Promise((resolve, reject) => {
+      if (typeof window === 'undefined' || !window.indexedDB) {
+        reject(new Error('IndexedDB not available'));
+        return;
+      }
+
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+      request.onerror = () => {
+        reject(new Error('Failed to open IndexedDB'));
+      };
+
+      request.onsuccess = () => {
+        this.db = request.result;
+        resolve(this.db);
+      };
+
+      request.onupgradeneeded = (event) => {
+        const db = (event.target as IDBOpenDBRequest).result;
+
+        // Lists store
+        if (!db.objectStoreNames.contains(STORES.LISTS)) {
+          const listsStore = db.createObjectStore(STORES.LISTS, { keyPath: 'id' });
+          listsStore.createIndex('userId', 'userId', { unique: false });
+          listsStore.createIndex('projectId', 'projectId', { unique: false });
+          listsStore.createIndex('_synced', '_synced', { unique: false });
+        }
+
+        // Citations store
+        if (!db.objectStoreNames.contains(STORES.CITATIONS)) {
+          const citationsStore = db.createObjectStore(STORES.CITATIONS, { keyPath: 'id' });
+          citationsStore.createIndex('listId', 'listId', { unique: false });
+          citationsStore.createIndex('_synced', '_synced', { unique: false });
+        }
+
+        // Projects store
+        if (!db.objectStoreNames.contains(STORES.PROJECTS)) {
+          const projectsStore = db.createObjectStore(STORES.PROJECTS, { keyPath: 'id' });
+          projectsStore.createIndex('userId', 'userId', { unique: false });
+          projectsStore.createIndex('_synced', '_synced', { unique: false });
+        }
+
+        // Sync queue store
+        if (!db.objectStoreNames.contains(STORES.SYNC_QUEUE)) {
+          const syncStore = db.createObjectStore(STORES.SYNC_QUEUE, { keyPath: 'id' });
+          syncStore.createIndex('entity', 'entity', { unique: false });
+          syncStore.createIndex('createdAt', 'createdAt', { unique: false });
+        }
+
+        // Cache meta store
+        if (!db.objectStoreNames.contains(STORES.CACHE_META)) {
+          db.createObjectStore(STORES.CACHE_META, { keyPath: 'key' });
+        }
+      };
+    });
+
+    return this.initPromise;
+  }
+
+  private async getStore(storeName: string, mode: IDBTransactionMode = 'readonly'): Promise<IDBObjectStore> {
+    const db = await this.init();
+    const transaction = db.transaction(storeName, mode);
+    return transaction.objectStore(storeName);
+  }
+
+  // Generic CRUD operations
+  private async put<T>(storeName: string, item: T): Promise<T> {
+    const store = await this.getStore(storeName, 'readwrite');
+    return new Promise((resolve, reject) => {
+      const request = store.put(item);
+      request.onsuccess = () => resolve(item);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  private async get<T>(storeName: string, id: string): Promise<T | undefined> {
+    const store = await this.getStore(storeName, 'readonly');
+    return new Promise((resolve, reject) => {
+      const request = store.get(id);
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  private async getAll<T>(storeName: string): Promise<T[]> {
+    const store = await this.getStore(storeName, 'readonly');
+    return new Promise((resolve, reject) => {
+      const request = store.getAll();
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  private async getAllByIndex<T>(storeName: string, indexName: string, value: IDBValidKey): Promise<T[]> {
+    const store = await this.getStore(storeName, 'readonly');
+    const index = store.index(indexName);
+    return new Promise((resolve, reject) => {
+      const request = index.getAll(value);
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  private async delete(storeName: string, id: string): Promise<void> {
+    const store = await this.getStore(storeName, 'readwrite');
+    return new Promise((resolve, reject) => {
+      const request = store.delete(id);
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  private async clear(storeName: string): Promise<void> {
+    const store = await this.getStore(storeName, 'readwrite');
+    return new Promise((resolve, reject) => {
+      const request = store.clear();
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  // Lists operations
+  async saveList(list: OfflineList): Promise<OfflineList> {
+    return this.put(STORES.LISTS, { ...list, _synced: false });
+  }
+
+  async getList(id: string): Promise<OfflineList | undefined> {
+    return this.get(STORES.LISTS, id);
+  }
+
+  async getAllLists(): Promise<OfflineList[]> {
+    return this.getAll(STORES.LISTS);
+  }
+
+  async getListsByUser(userId: string): Promise<OfflineList[]> {
+    return this.getAllByIndex(STORES.LISTS, 'userId', userId);
+  }
+
+  async getListsByProject(projectId: string): Promise<OfflineList[]> {
+    return this.getAllByIndex(STORES.LISTS, 'projectId', projectId);
+  }
+
+  async deleteList(id: string): Promise<void> {
+    return this.delete(STORES.LISTS, id);
+  }
+
+  async markListSynced(id: string): Promise<void> {
+    const list = await this.getList(id);
+    if (list) {
+      await this.put(STORES.LISTS, { ...list, _synced: true, _offline: false });
+    }
+  }
+
+  // Citations operations
+  async saveCitation(citation: OfflineCitation): Promise<OfflineCitation> {
+    return this.put(STORES.CITATIONS, { ...citation, _synced: false });
+  }
+
+  async getCitation(id: string): Promise<OfflineCitation | undefined> {
+    return this.get(STORES.CITATIONS, id);
+  }
+
+  async getAllCitations(): Promise<OfflineCitation[]> {
+    return this.getAll(STORES.CITATIONS);
+  }
+
+  async getCitationsByList(listId: string): Promise<OfflineCitation[]> {
+    return this.getAllByIndex(STORES.CITATIONS, 'listId', listId);
+  }
+
+  async deleteCitation(id: string): Promise<void> {
+    return this.delete(STORES.CITATIONS, id);
+  }
+
+  async markCitationSynced(id: string): Promise<void> {
+    const citation = await this.getCitation(id);
+    if (citation) {
+      await this.put(STORES.CITATIONS, { ...citation, _synced: true, _offline: false });
+    }
+  }
+
+  // Projects operations
+  async saveProject(project: OfflineProject): Promise<OfflineProject> {
+    return this.put(STORES.PROJECTS, { ...project, _synced: false });
+  }
+
+  async getProject(id: string): Promise<OfflineProject | undefined> {
+    return this.get(STORES.PROJECTS, id);
+  }
+
+  async getAllProjects(): Promise<OfflineProject[]> {
+    return this.getAll(STORES.PROJECTS);
+  }
+
+  async getProjectsByUser(userId: string): Promise<OfflineProject[]> {
+    return this.getAllByIndex(STORES.PROJECTS, 'userId', userId);
+  }
+
+  async deleteProject(id: string): Promise<void> {
+    return this.delete(STORES.PROJECTS, id);
+  }
+
+  async markProjectSynced(id: string): Promise<void> {
+    const project = await this.getProject(id);
+    if (project) {
+      await this.put(STORES.PROJECTS, { ...project, _synced: true, _offline: false });
+    }
+  }
+
+  // Sync queue operations
+  async addToSyncQueue(item: Omit<SyncQueueItem, 'id' | 'createdAt' | 'retryCount'>): Promise<SyncQueueItem> {
+    const syncItem: SyncQueueItem = {
+      ...item,
+      id: `sync_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+      createdAt: new Date().toISOString(),
+      retryCount: 0,
+    };
+    return this.put(STORES.SYNC_QUEUE, syncItem);
+  }
+
+  async getSyncQueue(): Promise<SyncQueueItem[]> {
+    const items = await this.getAll<SyncQueueItem>(STORES.SYNC_QUEUE);
+    return items.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+  }
+
+  async getSyncQueueByEntity(entity: SyncQueueItem['entity']): Promise<SyncQueueItem[]> {
+    return this.getAllByIndex(STORES.SYNC_QUEUE, 'entity', entity);
+  }
+
+  async updateSyncQueueItem(item: SyncQueueItem): Promise<SyncQueueItem> {
+    return this.put(STORES.SYNC_QUEUE, item);
+  }
+
+  async removeSyncQueueItem(id: string): Promise<void> {
+    return this.delete(STORES.SYNC_QUEUE, id);
+  }
+
+  async clearSyncQueue(): Promise<void> {
+    return this.clear(STORES.SYNC_QUEUE);
+  }
+
+  async getSyncQueueCount(): Promise<number> {
+    const items = await this.getSyncQueue();
+    return items.length;
+  }
+
+  // Cache metadata operations
+  async setCacheMeta(key: string, expiresIn?: number): Promise<CacheMeta> {
+    const meta: CacheMeta = {
+      key,
+      lastUpdated: new Date().toISOString(),
+      expiresAt: expiresIn ? new Date(Date.now() + expiresIn).toISOString() : undefined,
+    };
+    return this.put(STORES.CACHE_META, meta);
+  }
+
+  async getCacheMeta(key: string): Promise<CacheMeta | undefined> {
+    return this.get(STORES.CACHE_META, key);
+  }
+
+  async isCacheValid(key: string): Promise<boolean> {
+    const meta = await this.getCacheMeta(key);
+    if (!meta) return false;
+    if (!meta.expiresAt) return true;
+    return new Date(meta.expiresAt) > new Date();
+  }
+
+  // Utility methods
+  async getUnsyncedCount(): Promise<{ lists: number; citations: number; projects: number; total: number }> {
+    const [lists, citations, projects] = await Promise.all([
+      this.getAllByIndex<OfflineList>(STORES.LISTS, '_synced', false),
+      this.getAllByIndex<OfflineCitation>(STORES.CITATIONS, '_synced', false),
+      this.getAllByIndex<OfflineProject>(STORES.PROJECTS, '_synced', false),
+    ]);
+    return {
+      lists: lists.length,
+      citations: citations.length,
+      projects: projects.length,
+      total: lists.length + citations.length + projects.length,
+    };
+  }
+
+  async clearAllData(): Promise<void> {
+    await Promise.all([
+      this.clear(STORES.LISTS),
+      this.clear(STORES.CITATIONS),
+      this.clear(STORES.PROJECTS),
+      this.clear(STORES.SYNC_QUEUE),
+      this.clear(STORES.CACHE_META),
+    ]);
+  }
+
+  // Bulk operations for syncing
+  async bulkSaveLists(lists: OfflineList[]): Promise<void> {
+    const db = await this.init();
+    const transaction = db.transaction(STORES.LISTS, 'readwrite');
+    const store = transaction.objectStore(STORES.LISTS);
+
+    for (const list of lists) {
+      store.put({ ...list, _synced: true });
+    }
+
+    return new Promise((resolve, reject) => {
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+    });
+  }
+
+  async bulkSaveCitations(citations: OfflineCitation[]): Promise<void> {
+    const db = await this.init();
+    const transaction = db.transaction(STORES.CITATIONS, 'readwrite');
+    const store = transaction.objectStore(STORES.CITATIONS);
+
+    for (const citation of citations) {
+      store.put({ ...citation, _synced: true });
+    }
+
+    return new Promise((resolve, reject) => {
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+    });
+  }
+
+  async bulkSaveProjects(projects: OfflineProject[]): Promise<void> {
+    const db = await this.init();
+    const transaction = db.transaction(STORES.PROJECTS, 'readwrite');
+    const store = transaction.objectStore(STORES.PROJECTS);
+
+    for (const project of projects) {
+      store.put({ ...project, _synced: true });
+    }
+
+    return new Promise((resolve, reject) => {
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+    });
+  }
+}
+
+// Singleton instance
+export const offlineStore = new OfflineStore();

--- a/src/lib/pwa/pwa-utils.ts
+++ b/src/lib/pwa/pwa-utils.ts
@@ -1,0 +1,300 @@
+/**
+ * PWA Utilities
+ * Service worker registration, install prompt, and PWA state management
+ */
+
+export interface PWAState {
+  isInstalled: boolean;
+  isInstallable: boolean;
+  isOffline: boolean;
+  isUpdateAvailable: boolean;
+  swRegistration: ServiceWorkerRegistration | null;
+}
+
+export interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+type PWAListener = (state: PWAState) => void;
+
+class PWAManager {
+  private state: PWAState = {
+    isInstalled: false,
+    isInstallable: false,
+    isOffline: false,
+    isUpdateAvailable: false,
+    swRegistration: null,
+  };
+  private listeners: Set<PWAListener> = new Set();
+  private deferredPrompt: BeforeInstallPromptEvent | null = null;
+  private initialized = false;
+
+  async init(): Promise<void> {
+    if (this.initialized || typeof window === 'undefined') return;
+
+    // Check if already installed (standalone mode)
+    this.state.isInstalled =
+      window.matchMedia('(display-mode: standalone)').matches ||
+      (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
+
+    // Check initial offline status
+    this.state.isOffline = !navigator.onLine;
+
+    // Listen for online/offline
+    window.addEventListener('online', () => {
+      this.updateState({ isOffline: false });
+    });
+
+    window.addEventListener('offline', () => {
+      this.updateState({ isOffline: true });
+    });
+
+    // Listen for install prompt
+    window.addEventListener('beforeinstallprompt', (e) => {
+      e.preventDefault();
+      this.deferredPrompt = e as BeforeInstallPromptEvent;
+      this.updateState({ isInstallable: true });
+    });
+
+    // Listen for app installed
+    window.addEventListener('appinstalled', () => {
+      this.deferredPrompt = null;
+      this.updateState({ isInstalled: true, isInstallable: false });
+    });
+
+    // Register service worker
+    await this.registerServiceWorker();
+
+    this.initialized = true;
+  }
+
+  private async registerServiceWorker(): Promise<void> {
+    if (!('serviceWorker' in navigator)) {
+      console.log('[PWA] Service worker not supported');
+      return;
+    }
+
+    try {
+      const registration = await navigator.serviceWorker.register('/sw.js', {
+        scope: '/',
+      });
+
+      this.updateState({ swRegistration: registration });
+
+      // Check for updates
+      registration.addEventListener('updatefound', () => {
+        const newWorker = registration.installing;
+        if (!newWorker) return;
+
+        newWorker.addEventListener('statechange', () => {
+          if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+            this.updateState({ isUpdateAvailable: true });
+          }
+        });
+      });
+
+      // Listen for messages from service worker
+      navigator.serviceWorker.addEventListener('message', (event) => {
+        this.handleServiceWorkerMessage(event);
+      });
+
+      console.log('[PWA] Service worker registered');
+    } catch (error) {
+      console.error('[PWA] Service worker registration failed:', error);
+    }
+  }
+
+  private handleServiceWorkerMessage(event: MessageEvent) {
+    const { type } = event.data || {};
+
+    switch (type) {
+      case 'SYNC_TRIGGERED':
+        // Dispatch custom event for components to listen to
+        window.dispatchEvent(new CustomEvent('pwa-sync-triggered'));
+        break;
+
+      case 'CACHE_UPDATED':
+        window.dispatchEvent(new CustomEvent('pwa-cache-updated'));
+        break;
+    }
+  }
+
+  private updateState(partial: Partial<PWAState>) {
+    this.state = { ...this.state, ...partial };
+    this.notifyListeners();
+  }
+
+  private notifyListeners() {
+    this.listeners.forEach((listener) => listener({ ...this.state }));
+  }
+
+  subscribe(listener: PWAListener): () => void {
+    this.listeners.add(listener);
+    listener({ ...this.state });
+    return () => this.listeners.delete(listener);
+  }
+
+  getState(): PWAState {
+    return { ...this.state };
+  }
+
+  // Trigger install prompt
+  async promptInstall(): Promise<boolean> {
+    if (!this.deferredPrompt) {
+      console.log('[PWA] No install prompt available');
+      return false;
+    }
+
+    try {
+      await this.deferredPrompt.prompt();
+      const { outcome } = await this.deferredPrompt.userChoice;
+
+      if (outcome === 'accepted') {
+        console.log('[PWA] User accepted install');
+        this.deferredPrompt = null;
+        this.updateState({ isInstallable: false });
+        return true;
+      } else {
+        console.log('[PWA] User dismissed install');
+        return false;
+      }
+    } catch (error) {
+      console.error('[PWA] Install prompt error:', error);
+      return false;
+    }
+  }
+
+  // Apply service worker update
+  async applyUpdate(): Promise<void> {
+    const { swRegistration } = this.state;
+    if (!swRegistration?.waiting) return;
+
+    // Tell waiting SW to take over
+    swRegistration.waiting.postMessage({ type: 'SKIP_WAITING' });
+
+    // Reload page when new SW takes over
+    navigator.serviceWorker.addEventListener('controllerchange', () => {
+      window.location.reload();
+    });
+  }
+
+  // Skip waiting and activate new service worker
+  skipWaiting(): void {
+    const { swRegistration } = this.state;
+    if (swRegistration?.waiting) {
+      swRegistration.waiting.postMessage({ type: 'SKIP_WAITING' });
+    }
+  }
+
+  // Clear all caches
+  async clearCache(): Promise<void> {
+    const { swRegistration } = this.state;
+    if (!swRegistration?.active) return;
+
+    return new Promise((resolve) => {
+      const messageChannel = new MessageChannel();
+      messageChannel.port1.onmessage = () => resolve();
+      swRegistration.active!.postMessage({ type: 'CLEAR_CACHE' }, [messageChannel.port2]);
+    });
+  }
+
+  // Get cache size
+  async getCacheSize(): Promise<number> {
+    const { swRegistration } = this.state;
+    if (!swRegistration?.active) return 0;
+
+    return new Promise((resolve) => {
+      const messageChannel = new MessageChannel();
+      messageChannel.port1.onmessage = (event) => {
+        resolve(event.data?.size || 0);
+      };
+      swRegistration.active!.postMessage({ type: 'GET_CACHE_SIZE' }, [messageChannel.port2]);
+    });
+  }
+
+  // Precache a specific page
+  async precachePage(url: string): Promise<void> {
+    const { swRegistration } = this.state;
+    if (!swRegistration?.active) return;
+
+    swRegistration.active.postMessage({
+      type: 'PRECACHE_PAGE',
+      payload: { url },
+    });
+  }
+
+  // Check for updates manually
+  async checkForUpdates(): Promise<void> {
+    const { swRegistration } = this.state;
+    if (swRegistration) {
+      await swRegistration.update();
+    }
+  }
+
+  // Register for background sync
+  async registerBackgroundSync(tag: string): Promise<boolean> {
+    const { swRegistration } = this.state;
+    if (!swRegistration || !('sync' in swRegistration)) {
+      return false;
+    }
+
+    try {
+      await (swRegistration as ServiceWorkerRegistration & { sync: { register: (tag: string) => Promise<void> } }).sync.register(tag);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+// Singleton instance
+export const pwaManager = new PWAManager();
+
+// Format bytes to human readable
+export function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 Bytes';
+  const k = 1024;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+}
+
+// Check if PWA features are supported
+export function isPWASupported(): boolean {
+  return typeof window !== 'undefined' && 'serviceWorker' in navigator;
+}
+
+// Check if running in standalone mode (installed as PWA)
+export function isStandalone(): boolean {
+  if (typeof window === 'undefined') return false;
+
+  return (
+    window.matchMedia('(display-mode: standalone)').matches ||
+    (window.navigator as Navigator & { standalone?: boolean }).standalone === true
+  );
+}
+
+// Check if running in Electron
+export function isElectron(): boolean {
+  if (typeof window === 'undefined') return false;
+
+  return !!(window as Window & { electronAPI?: unknown }).electronAPI ||
+    navigator.userAgent.toLowerCase().includes('electron');
+}
+
+// Get platform info
+export function getPlatform(): 'ios' | 'android' | 'windows' | 'macos' | 'linux' | 'unknown' {
+  if (typeof window === 'undefined') return 'unknown';
+
+  const ua = navigator.userAgent.toLowerCase();
+  const platform = navigator.platform?.toLowerCase() || '';
+
+  if (/iphone|ipad|ipod/.test(ua)) return 'ios';
+  if (/android/.test(ua)) return 'android';
+  if (/win/.test(platform)) return 'windows';
+  if (/mac/.test(platform)) return 'macos';
+  if (/linux/.test(platform)) return 'linux';
+
+  return 'unknown';
+}

--- a/src/lib/pwa/sync-manager.ts
+++ b/src/lib/pwa/sync-manager.ts
@@ -1,0 +1,355 @@
+/**
+ * Sync Queue Manager
+ * Handles synchronization of offline operations when back online
+ */
+
+import { offlineStore, SyncQueueItem } from './offline-store';
+
+export type SyncStatus = 'idle' | 'syncing' | 'error' | 'success';
+
+export interface SyncResult {
+  success: boolean;
+  synced: number;
+  failed: number;
+  errors: Array<{ itemId: string; error: string }>;
+}
+
+export interface SyncManagerState {
+  isOnline: boolean;
+  isSyncing: boolean;
+  pendingCount: number;
+  lastSyncAt: string | null;
+  lastError: string | null;
+}
+
+type SyncListener = (state: SyncManagerState) => void;
+
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 1000;
+
+class SyncManager {
+  private listeners: Set<SyncListener> = new Set();
+  private state: SyncManagerState = {
+    isOnline: typeof navigator !== 'undefined' ? navigator.onLine : true,
+    isSyncing: false,
+    pendingCount: 0,
+    lastSyncAt: null,
+    lastError: null,
+  };
+  private syncInProgress = false;
+  private initialized = false;
+
+  async init(): Promise<void> {
+    if (this.initialized || typeof window === 'undefined') return;
+
+    // Listen for online/offline events
+    window.addEventListener('online', this.handleOnline);
+    window.addEventListener('offline', this.handleOffline);
+
+    // Update initial state
+    this.state.isOnline = navigator.onLine;
+    await this.updatePendingCount();
+
+    // Try to sync if we're online and have pending items
+    if (this.state.isOnline && this.state.pendingCount > 0) {
+      this.sync();
+    }
+
+    this.initialized = true;
+  }
+
+  private handleOnline = async () => {
+    this.updateState({ isOnline: true });
+    // Automatically sync when coming back online
+    await this.sync();
+  };
+
+  private handleOffline = () => {
+    this.updateState({ isOnline: false });
+  };
+
+  private updateState(partial: Partial<SyncManagerState>) {
+    this.state = { ...this.state, ...partial };
+    this.notifyListeners();
+  }
+
+  private notifyListeners() {
+    this.listeners.forEach((listener) => listener({ ...this.state }));
+  }
+
+  subscribe(listener: SyncListener): () => void {
+    this.listeners.add(listener);
+    // Immediately notify with current state
+    listener({ ...this.state });
+    return () => this.listeners.delete(listener);
+  }
+
+  getState(): SyncManagerState {
+    return { ...this.state };
+  }
+
+  async updatePendingCount(): Promise<number> {
+    try {
+      const count = await offlineStore.getSyncQueueCount();
+      this.updateState({ pendingCount: count });
+      return count;
+    } catch {
+      return 0;
+    }
+  }
+
+  // Queue operations for sync
+  async queueCreate(entity: SyncQueueItem['entity'], entityId: string, data: Record<string, unknown>, parentId?: string): Promise<void> {
+    await offlineStore.addToSyncQueue({
+      type: 'create',
+      entity,
+      entityId,
+      data,
+      parentId,
+    });
+    await this.updatePendingCount();
+  }
+
+  async queueUpdate(entity: SyncQueueItem['entity'], entityId: string, data: Record<string, unknown>, parentId?: string): Promise<void> {
+    await offlineStore.addToSyncQueue({
+      type: 'update',
+      entity,
+      entityId,
+      data,
+      parentId,
+    });
+    await this.updatePendingCount();
+  }
+
+  async queueDelete(entity: SyncQueueItem['entity'], entityId: string, parentId?: string): Promise<void> {
+    await offlineStore.addToSyncQueue({
+      type: 'delete',
+      entity,
+      entityId,
+      parentId,
+    });
+    await this.updatePendingCount();
+  }
+
+  // Process sync queue
+  async sync(): Promise<SyncResult> {
+    if (this.syncInProgress || !this.state.isOnline) {
+      return { success: false, synced: 0, failed: 0, errors: [] };
+    }
+
+    this.syncInProgress = true;
+    this.updateState({ isSyncing: true, lastError: null });
+
+    const result: SyncResult = {
+      success: true,
+      synced: 0,
+      failed: 0,
+      errors: [],
+    };
+
+    try {
+      const queue = await offlineStore.getSyncQueue();
+
+      for (const item of queue) {
+        try {
+          await this.processQueueItem(item);
+          await offlineStore.removeSyncQueueItem(item.id);
+          result.synced++;
+
+          // Mark the entity as synced
+          await this.markEntitySynced(item);
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+          if (item.retryCount < MAX_RETRIES) {
+            // Update retry count and try again later
+            await offlineStore.updateSyncQueueItem({
+              ...item,
+              retryCount: item.retryCount + 1,
+              lastError: errorMessage,
+            });
+          } else {
+            // Max retries reached, mark as failed
+            result.failed++;
+            result.errors.push({ itemId: item.id, error: errorMessage });
+          }
+        }
+      }
+
+      this.updateState({
+        lastSyncAt: new Date().toISOString(),
+        isSyncing: false,
+      });
+      await this.updatePendingCount();
+
+      result.success = result.failed === 0;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Sync failed';
+      this.updateState({ lastError: errorMessage, isSyncing: false });
+      result.success = false;
+    } finally {
+      this.syncInProgress = false;
+    }
+
+    return result;
+  }
+
+  private async processQueueItem(item: SyncQueueItem): Promise<void> {
+    const { type, entity, entityId, data, parentId } = item;
+
+    // Build API endpoint
+    let endpoint = '';
+    let method = '';
+    let body: string | undefined;
+
+    switch (entity) {
+      case 'list':
+        if (type === 'create') {
+          endpoint = '/api/lists';
+          method = 'POST';
+          body = JSON.stringify(data);
+        } else if (type === 'update') {
+          endpoint = `/api/lists/${entityId}`;
+          method = 'PUT';
+          body = JSON.stringify(data);
+        } else if (type === 'delete') {
+          endpoint = `/api/lists/${entityId}`;
+          method = 'DELETE';
+        }
+        break;
+
+      case 'citation':
+        if (type === 'create') {
+          endpoint = `/api/lists/${parentId}/citations`;
+          method = 'POST';
+          body = JSON.stringify(data);
+        } else if (type === 'update') {
+          endpoint = `/api/lists/${parentId}/citations/${entityId}`;
+          method = 'PUT';
+          body = JSON.stringify(data);
+        } else if (type === 'delete') {
+          endpoint = `/api/lists/${parentId}/citations/${entityId}`;
+          method = 'DELETE';
+        }
+        break;
+
+      case 'project':
+        if (type === 'create') {
+          endpoint = '/api/projects';
+          method = 'POST';
+          body = JSON.stringify(data);
+        } else if (type === 'update') {
+          endpoint = `/api/projects/${entityId}`;
+          method = 'PUT';
+          body = JSON.stringify(data);
+        } else if (type === 'delete') {
+          endpoint = `/api/projects/${entityId}`;
+          method = 'DELETE';
+        }
+        break;
+    }
+
+    if (!endpoint || !method) {
+      throw new Error(`Invalid sync operation: ${type} ${entity}`);
+    }
+
+    // Make the API request with retry logic
+    let lastError: Error | null = null;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        const response = await fetch(endpoint, {
+          method,
+          headers: body ? { 'Content-Type': 'application/json' } : undefined,
+          body,
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(`API error: ${response.status} - ${errorText}`);
+        }
+
+        return; // Success
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error('Unknown error');
+        if (attempt < 2) {
+          await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS * (attempt + 1)));
+        }
+      }
+    }
+
+    throw lastError || new Error('Failed after retries');
+  }
+
+  private async markEntitySynced(item: SyncQueueItem): Promise<void> {
+    const { entity, entityId } = item;
+
+    switch (entity) {
+      case 'list':
+        await offlineStore.markListSynced(entityId);
+        break;
+      case 'citation':
+        await offlineStore.markCitationSynced(entityId);
+        break;
+      case 'project':
+        await offlineStore.markProjectSynced(entityId);
+        break;
+    }
+  }
+
+  // Force retry all failed items
+  async retryFailed(): Promise<void> {
+    const queue = await offlineStore.getSyncQueue();
+    for (const item of queue) {
+      if (item.retryCount >= MAX_RETRIES) {
+        await offlineStore.updateSyncQueueItem({
+          ...item,
+          retryCount: 0,
+          lastError: undefined,
+        });
+      }
+    }
+    await this.sync();
+  }
+
+  // Clear all pending sync items
+  async clearQueue(): Promise<void> {
+    await offlineStore.clearSyncQueue();
+    await this.updatePendingCount();
+  }
+
+  destroy(): void {
+    if (typeof window === 'undefined') return;
+    window.removeEventListener('online', this.handleOnline);
+    window.removeEventListener('offline', this.handleOffline);
+    this.listeners.clear();
+    this.initialized = false;
+  }
+}
+
+// Singleton instance
+export const syncManager = new SyncManager();
+
+// React hook for sync state
+export function useSyncManager() {
+  if (typeof window === 'undefined') {
+    return {
+      state: {
+        isOnline: true,
+        isSyncing: false,
+        pendingCount: 0,
+        lastSyncAt: null,
+        lastError: null,
+      },
+      sync: async () => ({ success: true, synced: 0, failed: 0, errors: [] }),
+      retryFailed: async () => {},
+      clearQueue: async () => {},
+    };
+  }
+
+  return {
+    state: syncManager.getState(),
+    sync: () => syncManager.sync(),
+    retryFailed: () => syncManager.retryFailed(),
+    clearQueue: () => syncManager.clearQueue(),
+  };
+}

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -1,0 +1,71 @@
+/**
+ * Electron API Type Declarations
+ * Available in window.electronAPI when running in Electron
+ */
+
+interface ElectronAPI {
+  // Theme
+  getTheme: () => Promise<'light' | 'dark'>;
+  setTheme: (theme: 'light' | 'dark' | 'system') => void;
+  onThemeChange: (callback: (theme: 'light' | 'dark') => void) => () => void;
+
+  // Notifications
+  showNotification: (title: string, body: string) => void;
+
+  // App info
+  getAppInfo: () => Promise<{
+    name: string;
+    version: string;
+    platform: string;
+    arch: string;
+    electron: string;
+    chrome: string;
+    node: string;
+  }>;
+
+  // Online status
+  getOnlineStatus: () => Promise<boolean>;
+
+  // Updates
+  checkForUpdates: () => Promise<{ updateAvailable: boolean }>;
+
+  // External links
+  openExternal: (url: string) => void;
+
+  // Window controls
+  minimizeWindow: () => void;
+  maximizeWindow: () => void;
+  closeWindow: () => void;
+  isMaximized: () => Promise<boolean>;
+
+  // Navigation events
+  onNavigate: (callback: (path: string) => void) => () => void;
+
+  // Deep links
+  onDeepLink: (callback: (url: string) => void) => () => void;
+
+  // App events
+  onCreateList: (callback: () => void) => () => void;
+  onImport: (callback: () => void) => () => void;
+  onExport: (callback: () => void) => () => void;
+  onShowAbout: (callback: () => void) => () => void;
+
+  // Platform check
+  isElectron: boolean;
+  platform: NodeJS.Platform;
+}
+
+interface ElectronVersions {
+  node: string;
+  chrome: string;
+  electron: string;
+}
+
+declare global {
+  interface Window {
+    electronAPI?: ElectronAPI;
+    versions?: ElectronVersions;
+  }
+}
+
+export {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,11 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "electron",
+    "dist-electron",
+    "release",
+    "out",
+    "scripts"
   ]
 }


### PR DESCRIPTION
## Summary
- Add complete PWA infrastructure with offline support
- Add Electron desktop app wrapper for Windows, macOS, Linux
- Add Safari install banner for iOS/macOS users

## Features

### PWA Offline Support
- **IndexedDB offline store** - Client-side persistence for lists, citations, projects
- **Sync queue manager** - Queues operations when offline, auto-syncs when back online
- **Service worker** - Cache-first strategy for offline access
- **Offline indicator** - Shows pending items count with "queued for sync" message

### Electron Desktop App
- Native menu with keyboard shortcuts
- Window management (minimize, maximize, close)
- Deep link handling (`opencitation://`)
- Build configs for Windows, macOS, Linux

### Safari Install Banner
- Apple-style bottom banner for Safari users
- iOS: Shows share icon with "Add to Home Screen" instructions
- macOS: Shows "File → Add to Dock" instructions

## New npm Scripts
```bash
npm run electron:dev       # Development with hot reload
npm run electron:build     # Build for current platform
npm run electron:build:mac # Build for macOS
npm run electron:build:win # Build for Windows
npm run electron:build:linux # Build for Linux
```

## Test plan
- [ ] Test PWA install on Chrome/Edge
- [ ] Test Safari install banner on iOS/macOS Safari
- [ ] Test offline mode (disable network, create citation, re-enable)
- [ ] Verify sync queue processes when back online
- [ ] Test Electron dev mode with `npm run electron:dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)