### PR TITLE
⚡ Optimize label lookups in citation forms

### DIFF
--- a/scripts/benchmark-getlabel.js
+++ b/scripts/benchmark-getlabel.js
@@ -1,0 +1,128 @@
+const { performance } = require('perf_hooks');
+
+const CITATION_STYLES = [
+  { value: "apa", label: "APA 7th" },
+  { value: "mla", label: "MLA 9th" },
+  { value: "chicago", label: "Chicago 17th" },
+  { value: "harvard", label: "Harvard" },
+];
+
+const ACCESS_TYPES = [
+  { value: "web", label: "Web" },
+  { value: "print", label: "Print" },
+  { value: "database", label: "Database" },
+  { value: "app", label: "App" },
+  { value: "archive", label: "Archive" },
+];
+
+const SOURCE_TYPES = [
+  { value: "book", label: "Book" },
+  { value: "book-chapter", label: "Book Chapter" },
+  { value: "journal", label: "Journal" },
+  { value: "website", label: "Website" },
+  { value: "blog", label: "Blog" },
+  { value: "newspaper", label: "Newspaper" },
+  { value: "video", label: "Video" },
+  { value: "image", label: "Image" },
+  { value: "film", label: "Film" },
+  { value: "tv-series", label: "TV Series" },
+  { value: "tv-episode", label: "TV Episode" },
+  { value: "song", label: "Song" },
+  { value: "album", label: "Album" },
+  { value: "podcast-episode", label: "Podcast Episode" },
+  { value: "video-game", label: "Video Game" },
+  { value: "artwork", label: "Artwork" },
+  { value: "thesis", label: "Thesis / Dissertation" },
+  { value: "conference-paper", label: "Conference Paper" },
+  { value: "dataset", label: "Dataset" },
+  { value: "software", label: "Software / Code" },
+  { value: "preprint", label: "Preprint" },
+  { value: "social-media", label: "Social Media" },
+  { value: "ai-generated", label: "AI-Generated" },
+  { value: "interview", label: "Interview" },
+  { value: "government-report", label: "Government Report" },
+  { value: "legal-case", label: "Legal Case" },
+  { value: "encyclopedia", label: "Encyclopedia" },
+  { value: "miscellaneous", label: "Miscellaneous" },
+];
+
+// Baseline implementations
+const getStyleLabelBaseline = (value) =>
+  CITATION_STYLES.find(s => s.value === value)?.label || value;
+
+const getSourceLabelBaseline = (value) =>
+  SOURCE_TYPES.find(s => s.value === value)?.label || value;
+
+const getAccessLabelBaseline = (value) =>
+  ACCESS_TYPES.find(s => s.value === value)?.label || value;
+
+// Optimized implementations using maps
+const citationStyleMap = Object.fromEntries(CITATION_STYLES.map(s => [s.value, s.label]));
+const getStyleLabelOptimized = (value) => citationStyleMap[value] || value;
+
+const sourceTypeMap = Object.fromEntries(SOURCE_TYPES.map(s => [s.value, s.label]));
+const getSourceLabelOptimized = (value) => sourceTypeMap[value] || value;
+
+const accessTypeMap = Object.fromEntries(ACCESS_TYPES.map(s => [s.value, s.label]));
+const getAccessLabelOptimized = (value) => accessTypeMap[value] || value;
+
+// Map Map implementations (Map object instead of plain object)
+const citationStyleMapObj = new Map(CITATION_STYLES.map(s => [s.value, s.label]));
+const getStyleLabelOptimizedMap = (value) => citationStyleMapObj.get(value) || value;
+
+const sourceTypeMapObj = new Map(SOURCE_TYPES.map(s => [s.value, s.label]));
+const getSourceLabelOptimizedMap = (value) => sourceTypeMapObj.get(value) || value;
+
+const accessTypeMapObj = new Map(ACCESS_TYPES.map(s => [s.value, s.label]));
+const getAccessLabelOptimizedMap = (value) => accessTypeMapObj.get(value) || value;
+
+
+const ITERATIONS = 1000000;
+const testValues = {
+  style: ['apa', 'mla', 'chicago', 'harvard', 'unknown'],
+  source: ['book', 'video', 'miscellaneous', 'website', 'unknown'],
+  access: ['web', 'app', 'archive', 'print', 'unknown']
+};
+
+function runBenchmark() {
+  console.log(`Running benchmark with ${ITERATIONS} iterations...\n`);
+
+  // --- Baseline ---
+  const startBaseline = performance.now();
+  for (let i = 0; i < ITERATIONS; i++) {
+    getStyleLabelBaseline(testValues.style[i % 5]);
+    getSourceLabelBaseline(testValues.source[i % 5]);
+    getAccessLabelBaseline(testValues.access[i % 5]);
+  }
+  const endBaseline = performance.now();
+  const durationBaseline = endBaseline - startBaseline;
+
+  // --- Optimized (Plain Object) ---
+  const startOptimized = performance.now();
+  for (let i = 0; i < ITERATIONS; i++) {
+    getStyleLabelOptimized(testValues.style[i % 5]);
+    getSourceLabelOptimized(testValues.source[i % 5]);
+    getAccessLabelOptimized(testValues.access[i % 5]);
+  }
+  const endOptimized = performance.now();
+  const durationOptimized = endOptimized - startOptimized;
+
+  // --- Optimized (Map Object) ---
+  const startOptimizedMap = performance.now();
+  for (let i = 0; i < ITERATIONS; i++) {
+    getStyleLabelOptimizedMap(testValues.style[i % 5]);
+    getSourceLabelOptimizedMap(testValues.source[i % 5]);
+    getAccessLabelOptimizedMap(testValues.access[i % 5]);
+  }
+  const endOptimizedMap = performance.now();
+  const durationOptimizedMap = endOptimizedMap - startOptimizedMap;
+
+  console.log('--- Results ---');
+  console.log(`Baseline (.find): ${durationBaseline.toFixed(2)}ms`);
+  console.log(`Optimized (Record): ${durationOptimized.toFixed(2)}ms`);
+  console.log(`Optimized (Map): ${durationOptimizedMap.toFixed(2)}ms`);
+  console.log(`\nImprovement (Record): ${((durationBaseline - durationOptimized) / durationBaseline * 100).toFixed(2)}% faster`);
+  console.log(`Improvement (Map): ${((durationBaseline - durationOptimizedMap) / durationBaseline * 100).toFixed(2)}% faster`);
+}
+
+runBenchmark();

--- a/src/app/cite/page.tsx
+++ b/src/app/cite/page.tsx
@@ -68,6 +68,18 @@ const ACCESS_TYPES: { value: AccessType; label: string }[] = [
   { value: "archive", label: "Archive" },
 ];
 
+const STYLE_LABELS: Record<string, string> = Object.fromEntries(
+  CITATION_STYLES.map(s => [s.value, s.label])
+);
+
+const SOURCE_LABELS: Record<string, string> = Object.fromEntries(
+  SOURCE_TYPES.map(s => [s.value, s.label])
+);
+
+const ACCESS_LABELS: Record<string, string> = Object.fromEntries(
+  ACCESS_TYPES.map(s => [s.value, s.label])
+);
+
 interface RecentCitation {
   id: string;
   title: string;
@@ -1274,13 +1286,13 @@ function CitePageContent() {
   };
 
   const getStyleLabel = (value: CitationStyle) =>
-    CITATION_STYLES.find(s => s.value === value)?.label || value;
+    STYLE_LABELS[value] || value;
 
   const getSourceLabel = (value: SourceType) =>
-    SOURCE_TYPES.find(s => s.value === value)?.label || value;
+    SOURCE_LABELS[value] || value;
 
   const _getAccessLabel = (value: AccessType) =>
-    ACCESS_TYPES.find(s => s.value === value)?.label || value;
+    ACCESS_LABELS[value] || value;
 
   const handleSelectTemplate = (template: CitationTemplate) => {
     // Apply template settings


### PR DESCRIPTION
💡 **What:** 
Replaced O(N) `.find()` calls with O(1) dictionary lookups (`STYLE_LABELS`, `SOURCE_LABELS`, `ACCESS_LABELS`) in `src/app/cite/page.tsx`. These dictionaries are pre-computed once using `Object.fromEntries` at the module level when the file loads.

🎯 **Why:** 
The previous implementation performed an array iteration each time `getStyleLabel`, `getSourceLabel`, or `_getAccessLabel` was called, which scaled linearly with the size of the arrays (e.g., `SOURCE_TYPES` has ~28 items). Using direct key lookups avoids this unnecessary overhead and improves overall execution speed, especially since these functions are used during render or form manipulation.

📊 **Measured Improvement:** 
I measured this by writing a benchmark script (`scripts/benchmark-getlabel.js`) simulating 1,000,000 iterations of calls to all three functions.

- **Baseline (`.find`):** 379.49ms
- **Optimized (`Record`):** 76.47ms

**Improvement:** 79.85% faster execution over the baseline.

---
*PR created automatically by Jules for task [6342301787919374991](https://jules.google.com/task/6342301787919374991) started by @aicoder2009*