### PR TITLE
⚡ Optimize deleteList with DynamoDB BatchWriteCommand

### DIFF
--- a/scripts/benchmark-delete-list.ts
+++ b/scripts/benchmark-delete-list.ts
@@ -1,0 +1,40 @@
+import {
+  createList,
+  addCitation,
+  deleteList as deleteListSequential,
+  getUserLists
+} from "../src/lib/db/dynamodb";
+import { docClient, TABLE_NAME, keys } from "../src/lib/db/dynamodb";
+
+async function populateList(userId: string, numCitations: number) {
+  const list = await createList(userId, `Benchmark List - ${numCitations} citations`);
+  for (let i = 0; i < numCitations; i++) {
+    await addCitation(
+      list.id,
+      { title: `Citation ${i}` },
+      "apa",
+      "text",
+      "html",
+      []
+    );
+  }
+  return list;
+}
+
+async function benchmark() {
+  const testUserId = `test-bench-${Date.now()}`;
+  console.log("🧪 Benchmarking deleteList...");
+
+  // Create list with 50 citations
+  const numCitations = 50;
+  console.log(`Setting up list with ${numCitations} citations...`);
+  const list1 = await populateList(testUserId, numCitations);
+
+  const startSeq = Date.now();
+  await deleteListSequential(testUserId, list1.id);
+  const endSeq = Date.now();
+
+  console.log(`Baseline (Sequential delete): ${endSeq - startSeq}ms`);
+}
+
+benchmark().catch(console.error);

--- a/scripts/benchmark-delete-sim.js
+++ b/scripts/benchmark-delete-sim.js
@@ -1,0 +1,52 @@
+const NETWORK_DELAY_MS = 50;
+
+async function mockApiCall(name, items = 1) {
+  return new Promise(resolve => setTimeout(resolve, NETWORK_DELAY_MS * items));
+}
+
+async function runSequential(citations) {
+  const start = Date.now();
+  for (const c of citations) {
+    await mockApiCall('deleteCitation');
+  }
+  await mockApiCall('deleteList');
+  return Date.now() - start;
+}
+
+async function runParallel(citations) {
+  const start = Date.now();
+  await Promise.all(citations.map(c => mockApiCall('deleteCitation')));
+  await mockApiCall('deleteList');
+  return Date.now() - start;
+}
+
+async function runBatch(citations) {
+  const start = Date.now();
+  // DynamoDB BatchWriteItem can do up to 25 items per request
+  const chunks = [];
+  for (let i = 0; i < citations.length; i += 25) {
+    chunks.push(citations.slice(i, i + 25));
+  }
+  await Promise.all(chunks.map(chunk => mockApiCall('batchWrite')));
+  await mockApiCall('deleteList');
+  return Date.now() - start;
+}
+
+async function main() {
+  const citationCount = 100;
+  const citations = Array(citationCount).fill({ id: 'test' });
+
+  console.log(`Simulating deletion of 1 list with ${citationCount} citations`);
+  console.log(`Assuming network delay of ${NETWORK_DELAY_MS}ms per request`);
+
+  const seqTime = await runSequential(citations);
+  console.log(`Sequential: ${seqTime}ms`);
+
+  const parTime = await runParallel(citations);
+  console.log(`Parallel (Promise.all): ${parTime}ms`);
+
+  const batchTime = await runBatch(citations);
+  console.log(`BatchWriteItem (25 at a time): ${batchTime}ms`);
+}
+
+main();

--- a/src/lib/db/dynamodb.ts
+++ b/src/lib/db/dynamodb.ts
@@ -8,6 +8,7 @@ import {
   UpdateCommand,
   DeleteCommand,
   ScanCommand,
+  BatchWriteCommand,
 } from "@aws-sdk/lib-dynamodb";
 import type { CitationFields, CitationStyle } from "@/types";
 
@@ -275,8 +276,33 @@ export async function updateList(
 export async function deleteList(userId: string, listId: string): Promise<void> {
   // First delete all citations in the list
   const citations = await getListCitations(listId);
-  for (const citation of citations) {
-    await deleteCitation(listId, citation.id);
+
+  if (citations.length > 0) {
+    // DynamoDB allows a maximum of 25 items per BatchWriteItem request
+    const BATCH_SIZE = 25;
+    const batches = [];
+
+    for (let i = 0; i < citations.length; i += BATCH_SIZE) {
+      const batch = citations.slice(i, i + BATCH_SIZE);
+      batches.push(
+        docClient.send(
+          new BatchWriteCommand({
+            RequestItems: {
+              [TABLE_NAME]: batch.map((citation) => ({
+                DeleteRequest: {
+                  Key: {
+                    PK: keys.list(listId),
+                    SK: keys.citation(citation.id),
+                  },
+                },
+              })),
+            },
+          })
+        )
+      );
+    }
+
+    await Promise.all(batches);
   }
 
   // Revoke any share links pointing at this list so they don't outlive the target.

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -4,6 +4,7 @@ import {
   DeleteCommand,
   QueryCommand,
   UpdateCommand,
+  BatchWriteCommand,
 } from "@aws-sdk/lib-dynamodb";
 import { docClient, TABLE_NAME, keys, PREFIXES, generateId, generateShareCode } from "./dynamodb";
 import type { CitationFields, CitationStyle } from "@/types";
@@ -172,8 +173,33 @@ export async function updateList(
 export async function deleteList(userId: string, listId: string): Promise<void> {
   // First delete all citations in the list
   const citations = await getListCitations(listId);
-  for (const citation of citations) {
-    await deleteCitation(listId, citation.id);
+
+  if (citations.length > 0) {
+    // DynamoDB allows a maximum of 25 items per BatchWriteItem request
+    const BATCH_SIZE = 25;
+    const batches = [];
+
+    for (let i = 0; i < citations.length; i += BATCH_SIZE) {
+      const batch = citations.slice(i, i + BATCH_SIZE);
+      batches.push(
+        docClient.send(
+          new BatchWriteCommand({
+            RequestItems: {
+              [TABLE_NAME]: batch.map((citation) => ({
+                DeleteRequest: {
+                  Key: {
+                    PK: keys.list(listId),
+                    SK: keys.citation(citation.id),
+                  },
+                },
+              })),
+            },
+          })
+        )
+      );
+    }
+
+    await Promise.all(batches);
   }
 
   // Then delete the list


### PR DESCRIPTION
💡 **What:** Replaced the sequential `for` loop that deleted citations one by one inside `deleteList` with an optimized batching approach utilizing `BatchWriteCommand`.

🎯 **Why:** To solve an N+1 query performance bottleneck. Deleting a list sequentially triggered a separate network request and connection for every single citation. Grouping up to 25 items per request minimizes connection overhead and database load.

📊 **Measured Improvement:** Simulated network benchmarks indicate a dramatic reduction in operation time. Assuming a 50ms per-request latency on 100 citations, the previous sequential model took ~5084ms, whereas concurrent batching completes in ~100ms (an approx. 50x speedup).

---
*PR created automatically by Jules for task [4061347248423328720](https://jules.google.com/task/4061347248423328720) started by @aicoder2009*