### PR TITLE
⚡ Optimize project deletion with concurrent list updates

### DIFF
--- a/scripts/benchmark-delete-project.js
+++ b/scripts/benchmark-delete-project.js
@@ -1,0 +1,58 @@
+const { performance } = require('perf_hooks');
+
+// Simulated database operations
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function getUserLists() {
+  await delay(50); // Simulate network latency for fetch
+  return Array.from({ length: 20 }, (_, i) => ({
+    id: `list-${i}`,
+    projectId: 'test-project'
+  }));
+}
+
+async function updateList() {
+  await delay(20); // Simulate network latency for update
+}
+
+async function deleteProjectSequential() {
+  const start = performance.now();
+  const lists = await getUserLists();
+  for (const list of lists) {
+    if (list.projectId === 'test-project') {
+      await updateList();
+    }
+  }
+  await delay(20); // delete project
+  const end = performance.now();
+  return end - start;
+}
+
+async function deleteProjectConcurrent() {
+  const start = performance.now();
+  const lists = await getUserLists();
+
+  const updatePromises = lists
+    .filter(list => list.projectId === 'test-project')
+    .map(list => updateList());
+
+  await Promise.all(updatePromises);
+  await delay(20); // delete project
+
+  const end = performance.now();
+  return end - start;
+}
+
+async function runBenchmark() {
+  console.log('Running sequential benchmark...');
+  let seqTime = 0;
+  for (let i = 0; i < 5; i++) seqTime += await deleteProjectSequential();
+  console.log(`Sequential Average: ${seqTime / 5}ms`);
+
+  console.log('Running concurrent benchmark...');
+  let concTime = 0;
+  for (let i = 0; i < 5; i++) concTime += await deleteProjectConcurrent();
+  console.log(`Concurrent Average: ${concTime / 5}ms`);
+}
+
+runBenchmark().catch(console.error);

--- a/src/lib/db/dynamodb.ts
+++ b/src/lib/db/dynamodb.ts
@@ -418,11 +418,11 @@ export async function updateProject(
 export async function deleteProject(userId: string, projectId: string): Promise<void> {
   // Remove project association from lists (but don't delete them)
   const lists = await getUserLists(userId);
-  for (const list of lists) {
-    if (list.projectId === projectId) {
-      await updateList(userId, list.id, { projectId: null });
-    }
-  }
+  const updatePromises = lists
+    .filter(list => list.projectId === projectId)
+    .map(list => updateList(userId, list.id, { projectId: null }));
+
+  await Promise.all(updatePromises);
 
   // Revoke any share links pointing at this project.
   await deleteSharesForTarget(userId, "project", projectId);

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -490,11 +490,11 @@ export async function updateProject(
 export async function deleteProject(userId: string, projectId: string): Promise<void> {
   // First remove project association from all lists
   const lists = await getUserLists(userId);
-  for (const list of lists) {
-    if (list.projectId === projectId) {
-      await updateList(userId, list.id, { projectId: undefined });
-    }
-  }
+  const updatePromises = lists
+    .filter(list => list.projectId === projectId)
+    .map(list => updateList(userId, list.id, { projectId: undefined }));
+
+  await Promise.all(updatePromises);
 
   // Then delete the project
   await docClient.send(


### PR DESCRIPTION
💡 **What:** Replaced the sequential `for` loop in the `deleteProject` functions within `src/lib/db/queries.ts` and `src/lib/db/dynamodb.ts` with concurrent `Promise.all` execution for dissociating projects from lists.
🎯 **Why:** To eliminate an N+1 query pattern where each list update was awaited sequentially, unnecessarily increasing execution time when deleting a project with many associated lists.
📊 **Measured Improvement:** Created a benchmark script (`scripts/benchmark-delete-project.js`) simulating network latency. The optimization reduced execution time for a 20-list deletion from an average of ~478ms to ~92ms, an ~80% improvement.

---
*PR created automatically by Jules for task [2008880035753739984](https://jules.google.com/task/2008880035753739984) started by @aicoder2009*