### PR TITLE
ux: Improve accessibility of error dismissal buttons

### DIFF
--- a/src/app/lists/[id]/page.tsx
+++ b/src/app/lists/[id]/page.tsx
@@ -825,6 +825,7 @@ export default function ListDetailPage({ params }: { params: Promise<{ id: strin
               <button
                 onClick={() => setError(null)}
                 className="ml-2 text-red-500 hover:text-red-700"
+                aria-label="Dismiss error"
               >
                 [dismiss]
               </button>

--- a/src/app/lists/page.tsx
+++ b/src/app/lists/page.tsx
@@ -209,6 +209,7 @@ export default function ListsPage() {
               <button
                 onClick={() => setError(null)}
                 className="ml-2 text-red-500 hover:text-red-700"
+                aria-label="Dismiss error"
               >
                 [dismiss]
               </button>

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -329,6 +329,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
               <button
                 onClick={() => setError(null)}
                 className="ml-2 text-red-500 hover:text-red-700"
+                aria-label="Dismiss error"
               >
                 [dismiss]
               </button>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -249,6 +249,7 @@ export default function ProjectsPage() {
               <button
                 onClick={() => setError(null)}
                 className="ml-2 text-red-500 hover:text-red-700"
+                aria-label="Dismiss error"
               >
                 [dismiss]
               </button>


### PR DESCRIPTION
Added `aria-label="Dismiss error"` to the generic `[dismiss]` buttons in error banners across the application (Lists and Projects pages) to improve accessibility for screen readers.

---
*PR created automatically by Jules for task [6114662530046905525](https://jules.google.com/task/6114662530046905525) started by @aicoder2009*