### PR TITLE
⚡ Bolt: Optimize GET `/api/share` with concurrent fetching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [Concurrent Fetching in API Endpoints]
+**Learning:** Sequential, independent database queries within API routes (like `/api/share`) cause a measurable N+1 latency pattern as each await blocks the next, despite not depending on its results.
+**Action:** When enriching list items from external collections or making independent queries, group them into a single `Promise.all` block to resolve them concurrently and significantly reduce request overhead.

--- a/src/app/api/share/route.ts
+++ b/src/app/api/share/route.ts
@@ -22,11 +22,14 @@ export async function GET() {
       );
     }
 
-    const shares = await listUserShares(userId);
+    // Optimize: Fetch shares, lists, and projects concurrently to minimize database latency
+    const [shares, lists, projects] = await Promise.all([
+      listUserShares(userId),
+      getUserLists(userId),
+      getUserProjects(userId),
+    ]);
 
     // Enrich with target name so the UI can render without extra round-trips.
-    const lists = await getUserLists(userId);
-    const projects = await getUserProjects(userId);
     const listById = new Map(lists.map((l) => [l.id, l]));
     const projectById = new Map(projects.map((p) => [p.id, p]));
 


### PR DESCRIPTION
**What**: Replaced sequential `await` calls with `Promise.all` in the `GET /api/share` endpoint to fetch user shares, lists, and projects concurrently. Added a journal entry about this performance learning.

**Why**: To eliminate N+1 query latency caused by blocking awaits on independent database queries, thereby improving API response time.

**Impact**: Significantly reduces the response time of the `/api/share` endpoint.

**Measurement**: Verification can be done by observing the reduced response time of the `/api/share` endpoint in network tools. Tests were successfully run to verify the API logic remains functionally correct.

---
*PR created automatically by Jules for task [14314310357927851448](https://jules.google.com/task/14314310357927851448) started by @aicoder2009*