### PR TITLE
🎨 Palette: Improve accessibility of WikiCollapsible component

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Improve WikiCollapsible Accessibility
+**Learning:** Found that custom toggle buttons without explicit context (e.g., using generic text like "[hide]"/"[show]") fail to provide meaningful feedback to screen reader users about what content is being toggled. Adding contextual `aria-label` along with `aria-expanded` and `aria-controls` mappings via `useId` provides the necessary relationship context.
+**Action:** Always generate unique IDs using `useId` for toggleable content containers, map them to the control button via `aria-controls`, reflect the state with `aria-expanded`, and ensure the button`s text or `aria-label` provides adequate context about the target content.

--- a/src/components/wiki/wiki-collapsible.tsx
+++ b/src/components/wiki/wiki-collapsible.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useId } from "react";
 
 interface WikiCollapsibleProps {
   title: string;
@@ -14,6 +14,7 @@ export function WikiCollapsible({
   defaultOpen = true,
 }: WikiCollapsibleProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const contentId = useId();
 
   return (
     <div className="border border-wiki-border-light bg-wiki-offwhite">
@@ -21,12 +22,15 @@ export function WikiCollapsible({
         <span className="font-medium text-sm">{title}</span>
         <button
           onClick={() => setIsOpen(!isOpen)}
+          aria-expanded={isOpen}
+          aria-controls={contentId}
+          aria-label={`${isOpen ? "Hide" : "Show"} ${title}`}
           className="text-wiki-link text-sm hover:underline"
         >
           [{isOpen ? "hide" : "show"}]
         </button>
       </div>
-      {isOpen && <div className="px-4 py-3">{children}</div>}
+      {isOpen && <div id={contentId} className="px-4 py-3">{children}</div>}
     </div>
   );
 }


### PR DESCRIPTION
💡 **What:** Added `aria-controls`, `aria-expanded`, and a contextual `aria-label` to the `WikiCollapsible` toggle button, generating unique relationship IDs via React's `useId` hook.
🎯 **Why:** To improve accessibility for screen reader users by providing explicit state context ("expanded" vs. "collapsed") and clear semantic relationships instead of just exposing ambiguous visual text like "[hide]" or "[show]".
♿ **Accessibility:** This directly enhances keyboard and screen reader navigation context, meeting baseline ARIA disclosure widget patterns.

---
*PR created automatically by Jules for task [9092937298992659040](https://jules.google.com/task/9092937298992659040) started by @aicoder2009*