### PR TITLE
🎨 Palette: Improve accessibility of WikiCollapsible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessible Collapsibles
+**Learning:** React interactive widgets like collapsibles need unique identifiers to properly map `aria-controls` from the trigger to the content.
+**Action:** Use React's `useId` hook to generate these unique IDs reliably, ensuring correct screen reader context without ID collisions when multiple components are rendered on the same page.

--- a/src/components/wiki/wiki-collapsible.tsx
+++ b/src/components/wiki/wiki-collapsible.tsx
@@ -1,6 +1,7 @@
+// src/components/wiki/wiki-collapsible.tsx
 "use client";
 
-import { useState } from "react";
+import { useState, useId } from "react";
 
 interface WikiCollapsibleProps {
   title: string;
@@ -14,6 +15,7 @@ export function WikiCollapsible({
   defaultOpen = true,
 }: WikiCollapsibleProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const contentId = useId();
 
   return (
     <div className="border border-wiki-border-light bg-wiki-offwhite">
@@ -22,11 +24,18 @@ export function WikiCollapsible({
         <button
           onClick={() => setIsOpen(!isOpen)}
           className="text-wiki-link text-sm hover:underline"
+          aria-expanded={isOpen}
+          aria-controls={contentId}
+          aria-label={`${isOpen ? "Hide" : "Show"} ${title}`}
         >
           [{isOpen ? "hide" : "show"}]
         </button>
       </div>
-      {isOpen && <div className="px-4 py-3">{children}</div>}
+      {isOpen && (
+        <div id={contentId} className="px-4 py-3">
+          {children}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
💡 **What:** The UX enhancement added `useId` to generate a unique ID for the collapsible content. It also added `aria-expanded`, `aria-controls`, and `aria-label` to the toggle button.
🎯 **Why:** To ensure screen reader users have proper context when navigating the collapsible widget, knowing its state and what it controls.
📸 **Before/After:** The UI remains visually unchanged as this is a structural screen-reader accessibility enhancement.
♿ **Accessibility:** Added ARIA attributes to map the toggle button to the collapsible content container and reflect its expanded/collapsed state.

---
*PR created automatically by Jules for task [4247003913079704533](https://jules.google.com/task/4247003913079704533) started by @aicoder2009*