### PR TITLE
🎨 Palette: Improve accessibility of WikiCollapsible

### DIFF
--- a/src/components/wiki/wiki-collapsible.tsx
+++ b/src/components/wiki/wiki-collapsible.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useId } from "react";
 
 interface WikiCollapsibleProps {
   title: string;
@@ -14,6 +14,7 @@ export function WikiCollapsible({
   defaultOpen = true,
 }: WikiCollapsibleProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const contentId = useId();
 
   return (
     <div className="border border-wiki-border-light bg-wiki-offwhite">
@@ -22,11 +23,18 @@ export function WikiCollapsible({
         <button
           onClick={() => setIsOpen(!isOpen)}
           className="text-wiki-link text-sm hover:underline"
+          aria-expanded={isOpen}
+          aria-controls={isOpen ? contentId : undefined}
+          aria-label={`${isOpen ? "Hide" : "Show"} ${title}`}
         >
           [{isOpen ? "hide" : "show"}]
         </button>
       </div>
-      {isOpen && <div className="px-4 py-3">{children}</div>}
+      {isOpen && (
+        <div id={contentId} className="px-4 py-3">
+          {children}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
🎨 **Palette: UX Improvement for WikiCollapsible**

💡 **What:** Improved the accessibility footprint of the `WikiCollapsible` component which acts as an accordion widget.
🎯 **Why:** To provide robust context to assistive tech like screen readers, which previously only saw `[hide]` or `[show]` with no linkage to the content container.
♿ **Accessibility:**
- Added robust state linking via `aria-controls` conditionally referencing a generated deterministic `useId` mapping.
- Added `aria-expanded` to clearly mark expansion state.
- Added an explicit and clear `aria-label` (e.g. "Show Contents") over the non-descriptive nested visual text representation.

---
*PR created automatically by Jules for task [10140147069264058154](https://jules.google.com/task/10140147069264058154) started by @aicoder2009*