### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XSS vulnerability in Markdown rendering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The application was passing unvalidated HTML variables, specifically `citation.formattedHtml`, to React's `dangerouslySetInnerHTML` prop in multiple components (`src/components/wiki/sortable-citation.tsx`, `src/app/cite/page.tsx`, `src/app/share/[code]/page.tsx`).
 **Learning:** This is a classic pattern for Cross-Site Scripting (XSS). If a citation's contents originated from an untrusted source or were maliciously formatted, an attacker could execute arbitrary scripts in a user's session when the citation is rendered.
 **Prevention:** Always sanitize any untrusted or dynamic HTML before rendering it in React. In a Next.js (SSR) application, use a library like `isomorphic-dompurify` to safely strip malicious scripts from the HTML payload on both the client and server side without hydration errors.
+
+## 2025-05-03 - Cross-Site Scripting (XSS) via Unsanitized Markdown Rendering
+**Vulnerability:** The application was passing the output of `marked()` directly into React's `dangerouslySetInnerHTML` in multiple documentation pages (`src/app/docs/changelog/page.tsx` and via `src/lib/docs.ts`).
+**Learning:** The `marked` library does not sanitize HTML by default. If a user controlled the markdown input, or if an upstream source (like a GitHub release body) were compromised, malicious scripts could be executed in the victim's browser.
+**Prevention:** Always wrap the output of markdown parsers (like `marked`) with a dedicated sanitizer (like `DOMPurify.sanitize()`) before injecting it into the DOM, even for internal or trusted-seeming sources (defense in depth).

--- a/src/app/docs/changelog/page.tsx
+++ b/src/app/docs/changelog/page.tsx
@@ -1,6 +1,7 @@
 import { WikiBreadcrumbs } from "@/components/wiki/wiki-breadcrumbs";
 import { getGitHubReleases } from "@/lib/github";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export const metadata = { title: "Changelog — OpenCitation" };
 
@@ -81,7 +82,7 @@ export default async function ChangelogPage() {
                 <div
                   className="docs-content px-4 py-4"
                   dangerouslySetInnerHTML={{
-                    __html: marked(release.body) as string,
+                    __html: DOMPurify.sanitize(marked(release.body) as string),
                   }}
                 />
               ) : (

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,9 +1,10 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export async function getDocContent(slug: string): Promise<string> {
   const filePath = join(process.cwd(), "docs/content", `${slug}.md`);
   const markdown = readFileSync(filePath, "utf-8");
-  return await marked(markdown);
+  return DOMPurify.sanitize(await marked(markdown));
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The output of `marked()` was being passed directly into React's `dangerouslySetInnerHTML` in documentation and changelog pages without sanitization. `marked` does not sanitize HTML by default.
🎯 Impact: If a user controlled the markdown input or if an upstream source (e.g., GitHub release notes) were compromised, malicious scripts could be executed in the victim's browser leading to session hijacking or unauthorized actions.
🔧 Fix: Wrapped the output of `marked()` with `DOMPurify.sanitize()` using the `isomorphic-dompurify` library to safely neutralize any malicious HTML payloads on both the server and client.
✅ Verification: Ran `pnpm test:run` and visual Playwright verification of the changelog rendering to ensure documentation layout remains intact. Tests pass and UI is unaffected.

---
*PR created automatically by Jules for task [5832643581576242474](https://jules.google.com/task/5832643581576242474) started by @aicoder2009*