### PR TITLE
🛡️ Sentinel: [HIGH] Sanitize markdown output to prevent XSS

### DIFF
--- a/src/app/docs/changelog/page.tsx
+++ b/src/app/docs/changelog/page.tsx
@@ -1,6 +1,7 @@
 import { WikiBreadcrumbs } from "@/components/wiki/wiki-breadcrumbs";
 import { getGitHubReleases, getGitHubCommits } from "@/lib/github";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export const metadata = { title: "Changelog — OpenCitation" };
 
@@ -91,7 +92,7 @@ export default async function ChangelogPage() {
               {release.body ? (
                 <div
                   className="docs-content px-4 py-4"
-                  dangerouslySetInnerHTML={{ __html: marked(release.body) as string }}
+                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked(release.body) as string) }}
                 />
               ) : (
                 <p className="px-4 py-4 text-sm text-wiki-text-muted italic">No release notes.</p>

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,9 +1,10 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export async function getDocContent(slug: string): Promise<string> {
   const filePath = join(process.cwd(), "docs/content", `${slug}.md`);
   const markdown = readFileSync(filePath, "utf-8");
-  return await marked(markdown);
+  return DOMPurify.sanitize(await marked(markdown));
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Markdown was converted to HTML using `marked` and injected directly into the DOM via `dangerouslySetInnerHTML` without sanitization.
🎯 Impact: If malicious markdown were fetched (e.g. from GitHub releases), it could execute arbitrary scripts in the user's session.
🔧 Fix: Wrapped `marked()` outputs with `DOMPurify.sanitize()` using the existing `isomorphic-dompurify` package in `src/lib/docs.ts` and `src/app/docs/changelog/page.tsx`.
✅ Verification: Ran `pnpm test:run` and `pnpm lint`, and verified production build with `pnpm build`.

---
*PR created automatically by Jules for task [12412866195584666050](https://jules.google.com/task/12412866195584666050) started by @aicoder2009*