### PR TITLE
⚡ Bolt: Concurrent DB fetching in share API

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-04 - [Concurrent Database Fetching in Share API]
+**Learning:** Sequential database operations can significantly increase latency when the operations are independent, such as fetching shares, user lists, and user projects.
+**Action:** Use `Promise.all` to execute independent database calls concurrently whenever possible to minimize latency, particularly in API endpoints designed for fetching data to enrich responses.

--- a/src/app/api/share/route.ts
+++ b/src/app/api/share/route.ts
@@ -22,11 +22,12 @@ export async function GET() {
       );
     }
 
-    const shares = await listUserShares(userId);
-
-    // Enrich with target name so the UI can render without extra round-trips.
-    const lists = await getUserLists(userId);
-    const projects = await getUserProjects(userId);
+    // Fetch shares, lists, and projects concurrently to minimize database latency.
+    const [shares, lists, projects] = await Promise.all([
+      listUserShares(userId),
+      getUserLists(userId),
+      getUserProjects(userId),
+    ]);
     const listById = new Map(lists.map((l) => [l.id, l]));
     const projectById = new Map(projects.map((p) => [p.id, p]));
 


### PR DESCRIPTION
💡 What: Refactored `src/app/api/share/route.ts` to execute database queries (`listUserShares`, `getUserLists`, `getUserProjects`) concurrently using `Promise.all`.
🎯 Why: Previously, these DB calls were executing sequentially. Since they do not depend on each other, waiting for one to finish before starting the next adds unnecessary latency to the `GET /api/share` endpoint.
📊 Impact: Expected reduction in database latency, directly speeding up the share endpoint response time (especially noticeable when network latency to DynamoDB or the local store is higher).
🔬 Measurement: Verify by executing `pnpm test src/app/api/share/route.test.ts` to ensure tests continue passing. Also observed the time reduction theoretically from $O(a + b + c)$ to $O(\max(a, b, c))$.

---
*PR created automatically by Jules for task [16193657390843495962](https://jules.google.com/task/16193657390843495962) started by @aicoder2009*