### PR TITLE
🎨 Palette: Improve WikiCollapsible accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - Accessible Collapsible Buttons
+**Learning:** Generic interactive controls like "[hide]/[show]" buttons on collapsible widgets are ambiguous to screen readers since they provide no context on *what* is being hidden or shown.
+**Action:** Use contextual `aria-label`s (e.g., "Hide [Title]") alongside proper `aria-expanded` and `aria-controls` mappings via `useId()` to ensure robust keyboard accessibility without ID collisions.

--- a/src/components/wiki/wiki-collapsible.tsx
+++ b/src/components/wiki/wiki-collapsible.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useId } from "react";
 
 interface WikiCollapsibleProps {
   title: string;
@@ -14,6 +14,7 @@ export function WikiCollapsible({
   defaultOpen = true,
 }: WikiCollapsibleProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const contentId = useId();
 
   return (
     <div className="border border-wiki-border-light bg-wiki-offwhite">
@@ -21,12 +22,19 @@ export function WikiCollapsible({
         <span className="font-medium text-sm">{title}</span>
         <button
           onClick={() => setIsOpen(!isOpen)}
+          aria-expanded={isOpen}
+          aria-controls={contentId}
+          aria-label={`${isOpen ? "Hide" : "Show"} ${title}`}
           className="text-wiki-link text-sm hover:underline"
         >
           [{isOpen ? "hide" : "show"}]
         </button>
       </div>
-      {isOpen && <div className="px-4 py-3">{children}</div>}
+      {isOpen && (
+        <div id={contentId} className="px-4 py-3">
+          {children}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
💡 **What:** Added `aria-expanded`, `aria-controls`, and a dynamic `aria-label` to the toggle button in the `WikiCollapsible` component, mapped securely to content using React's `useId()` hook.
🎯 **Why:** To prevent ambiguity for users relying on assistive technologies, as the visual text is restricted to just "[hide]" or "[show]", giving no context on what is being toggled.
📸 **Before/After:** No visual change.
♿ **Accessibility:** Screen readers now announce contextual labels like "Hide First Section" rather than just "hide button". Evaluated functionality via Playwright screenshot tests and keyboard navigation.

Also journaled this learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [17156791631974695617](https://jules.google.com/task/17156791631974695617) started by @aicoder2009*