### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in markdown rendering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The application was passing unvalidated HTML variables, specifically `citation.formattedHtml`, to React's `dangerouslySetInnerHTML` prop in multiple components (`src/components/wiki/sortable-citation.tsx`, `src/app/cite/page.tsx`, `src/app/share/[code]/page.tsx`).
 **Learning:** This is a classic pattern for Cross-Site Scripting (XSS). If a citation's contents originated from an untrusted source or were maliciously formatted, an attacker could execute arbitrary scripts in a user's session when the citation is rendered.
 **Prevention:** Always sanitize any untrusted or dynamic HTML before rendering it in React. In a Next.js (SSR) application, use a library like `isomorphic-dompurify` to safely strip malicious scripts from the HTML payload on both the client and server side without hydration errors.
+
+## 2025-02-28 - [XSS via un-sanitized Markdown output]
+**Vulnerability:** The markdown parsed HTML was being rendered directly via React's `dangerouslySetInnerHTML` in the `src/app/docs/changelog/page.tsx` and the `src/lib/docs.ts` utility that feeds multiple documentation pages. This is problematic since marked output is not inherently safe, allowing for Cross-Site Scripting (XSS) if untrusted content was processed.
+**Learning:** Using libraries to parse markdown like `marked` without wrapping their outputs into a sanitizer when rendering through React properties like `dangerouslySetInnerHTML` can open up paths to execute arbitrary JS in a user's browser.
+**Prevention:** It is required to sanitize untrusted markup. Using tools like `isomorphic-dompurify` to parse and strip out malicious payload effectively patches XSS vulnerabilities stemming from unsafe markdown parsing output.

--- a/src/app/docs/changelog/page.tsx
+++ b/src/app/docs/changelog/page.tsx
@@ -1,6 +1,7 @@
 import { WikiBreadcrumbs } from "@/components/wiki/wiki-breadcrumbs";
 import { getGitHubReleases, getGitHubCommits } from "@/lib/github";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export const metadata = { title: "Changelog — OpenCitation" };
 
@@ -91,7 +92,7 @@ export default async function ChangelogPage() {
               {release.body ? (
                 <div
                   className="docs-content px-4 py-4"
-                  dangerouslySetInnerHTML={{ __html: marked(release.body) as string }}
+                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked(release.body) as string) }}
                 />
               ) : (
                 <p className="px-4 py-4 text-sm text-wiki-text-muted italic">No release notes.</p>

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export async function getDocContent(slug: string): Promise<string> {
   const filePath = join(process.cwd(), "docs/content", `${slug}.md`);
   const markdown = readFileSync(filePath, "utf-8");
-  return await marked(markdown);
+  const html = await marked(markdown);
+  return DOMPurify.sanitize(html);
 }


### PR DESCRIPTION
This PR fixes a Cross-Site Scripting (XSS) vulnerability found where markdown-parsed content from the `marked` library was directly injected into the DOM via React's `dangerouslySetInnerHTML`. The generated HTML is now sanitized using `isomorphic-dompurify`.
- Fixes `src/app/docs/changelog/page.tsx`
- Fixes `src/lib/docs.ts`
- Added the necessary security journaling entry.

---
*PR created automatically by Jules for task [13572087779279619555](https://jules.google.com/task/13572087779279619555) started by @aicoder2009*