### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in marked output

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The application was passing unvalidated HTML variables, specifically `citation.formattedHtml`, to React's `dangerouslySetInnerHTML` prop in multiple components (`src/components/wiki/sortable-citation.tsx`, `src/app/cite/page.tsx`, `src/app/share/[code]/page.tsx`).
 **Learning:** This is a classic pattern for Cross-Site Scripting (XSS). If a citation's contents originated from an untrusted source or were maliciously formatted, an attacker could execute arbitrary scripts in a user's session when the citation is rendered.
 **Prevention:** Always sanitize any untrusted or dynamic HTML before rendering it in React. In a Next.js (SSR) application, use a library like `isomorphic-dompurify` to safely strip malicious scripts from the HTML payload on both the client and server side without hydration errors.
+
+## 2026-05-05 - [XSS via unsanitized marked library output]
+**Vulnerability:** The application was parsing Markdown using the `marked` library and passing the resulting HTML directly to React's `dangerouslySetInnerHTML` prop in `src/app/docs/changelog/page.tsx` and `src/lib/docs.ts`.
+**Learning:** The `marked` library does not sanitize HTML by default. If the source Markdown contains raw, malicious HTML tags (e.g., `<script>`), `marked` will pass them through untouched, leading to Cross-Site Scripting (XSS) when rendered by React. Even content from seemingly trusted sources like local files or GitHub release notes should be treated as untrusted.
+**Prevention:** Always wrap the output of Markdown parsers like `marked` with a dedicated HTML sanitizer like `DOMPurify` (using `isomorphic-dompurify` in Next.js) before rendering it with `dangerouslySetInnerHTML`.

--- a/src/app/docs/changelog/page.tsx
+++ b/src/app/docs/changelog/page.tsx
@@ -1,6 +1,7 @@
 import { WikiBreadcrumbs } from "@/components/wiki/wiki-breadcrumbs";
 import { getGitHubReleases, getGitHubCommits } from "@/lib/github";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export const metadata = { title: "Changelog — OpenCitation" };
 
@@ -91,7 +92,7 @@ export default async function ChangelogPage() {
               {release.body ? (
                 <div
                   className="docs-content px-4 py-4"
-                  dangerouslySetInnerHTML={{ __html: marked(release.body) as string }}
+                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked(release.body) as string) }}
                 />
               ) : (
                 <p className="px-4 py-4 text-sm text-wiki-text-muted italic">No release notes.</p>

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export async function getDocContent(slug: string): Promise<string> {
   const filePath = join(process.cwd(), "docs/content", `${slug}.md`);
   const markdown = readFileSync(filePath, "utf-8");
-  return await marked(markdown);
+  const html = await marked(markdown);
+  return DOMPurify.sanitize(html);
 }


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: Unsanitized HTML output from the `marked` Markdown parser was passed to `dangerouslySetInnerHTML`.
* 🎯 Impact: Potential Cross-Site Scripting (XSS) if malicious HTML is embedded in Markdown files or GitHub release notes.
* 🔧 Fix: Wrapped all `marked` parser outputs with `DOMPurify.sanitize()` using `isomorphic-dompurify`.
* ✅ Verification: Verified by running `pnpm test` and ensuring documentation pages still render correctly.

---
*PR created automatically by Jules for task [230213522889217777](https://jules.google.com/task/230213522889217777) started by @aicoder2009*