### PR TITLE
🎨 Palette: Improve WikiCollapsible accessibility with ARIA attributes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-12 - Added ARIA attributes to WikiCollapsible
+**Learning:** Found an accessibility pattern for collapsible sections where the toggle button lacked explicit ARIA associations (`aria-expanded`, `aria-controls`) and contextually meaningful labels (relied on generic `[show]`/`[hide]` text).
+**Action:** Used `useId()` to generate a unique control ID linking the button to the content `div`, and composed an `aria-label` combining the toggle state with the section `title` to provide full context to screen readers.

--- a/src/components/wiki/wiki-collapsible.tsx
+++ b/src/components/wiki/wiki-collapsible.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useId } from "react";
 
 interface WikiCollapsibleProps {
   title: string;
@@ -14,6 +14,7 @@ export function WikiCollapsible({
   defaultOpen = true,
 }: WikiCollapsibleProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const contentId = useId();
 
   return (
     <div className="border border-wiki-border-light bg-wiki-offwhite">
@@ -22,11 +23,18 @@ export function WikiCollapsible({
         <button
           onClick={() => setIsOpen(!isOpen)}
           className="text-wiki-link text-sm hover:underline"
+          aria-expanded={isOpen}
+          aria-controls={contentId}
+          aria-label={`${isOpen ? "Hide" : "Show"} ${title}`}
         >
           [{isOpen ? "hide" : "show"}]
         </button>
       </div>
-      {isOpen && <div className="px-4 py-3">{children}</div>}
+      {isOpen && (
+        <div id={contentId} className="px-4 py-3">
+          {children}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
🎨 **Palette: Improved Accessibility for WikiCollapsible**

**💡 What:** 
Added proper ARIA attributes to the `WikiCollapsible` component to improve its keyboard and screen reader accessibility. It now features `aria-expanded`, `aria-controls`, and an `aria-label` that provides more context than just the generic `[show]`/`[hide]` visible text.

**🎯 Why:** 
For screen reader users, encountering a button that just says `[show]` or `[hide]` without context of *what* is being shown/hidden is confusing. Further, the button wasn't explicitly linked to the section of the DOM it was revealing (`aria-controls`), nor did it correctly announce its collapsed/expanded state (`aria-expanded`). This change brings the component in line with standard web accessibility patterns for disclosures.

**♿ Accessibility:**
- Uses `useId()` to guarantee unique DOM IDs.
- Adds `aria-expanded` mapped to the `isOpen` state.
- Adds `aria-controls` mapping the button to the hidden `div` content.
- Generates `aria-label` dynamically (e.g., "Hide Website Fields", "Show Abstract").

---
*PR created automatically by Jules for task [9825451977119599876](https://jules.google.com/task/9825451977119599876) started by @aicoder2009*