### PR TITLE
🎨 Palette: Add accessibility attributes to WikiCollapsible component

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - Accessible Collapsibles
+**Learning:** For accessible React interactive widgets (like tabs or collapsibles), using React's `useId` hook to generate unique IDs for `aria-controls` mappings, and reflecting state with `aria-expanded`, ensures correct screen reader context without ID collisions. Additionally, generic visual text (like "[hide]" or "[show]") requires a contextual `aria-label` (e.g., "Hide [Title]") for screen reader users to have proper context when navigating by controls.
+**Action:** Always provide contextual `aria-label`s for buttons using generic text, and use `useId` for mapping `aria-controls` to the content container's `id`.

--- a/src/components/wiki/wiki-collapsible.tsx
+++ b/src/components/wiki/wiki-collapsible.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useId } from "react";
 
 interface WikiCollapsibleProps {
   title: string;
@@ -14,6 +14,7 @@ export function WikiCollapsible({
   defaultOpen = true,
 }: WikiCollapsibleProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const contentId = useId();
 
   return (
     <div className="border border-wiki-border-light bg-wiki-offwhite">
@@ -21,12 +22,19 @@ export function WikiCollapsible({
         <span className="font-medium text-sm">{title}</span>
         <button
           onClick={() => setIsOpen(!isOpen)}
+          aria-expanded={isOpen}
+          aria-controls={isOpen ? contentId : undefined}
+          aria-label={`${isOpen ? "Hide" : "Show"} ${title}`}
           className="text-wiki-link text-sm hover:underline"
         >
           [{isOpen ? "hide" : "show"}]
         </button>
       </div>
-      {isOpen && <div className="px-4 py-3">{children}</div>}
+      {isOpen && (
+        <div id={contentId} className="px-4 py-3">
+          {children}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
💡 **What**: Added `useId` to automatically generate unique `id` values for the content container of `WikiCollapsible`. Connected the toggle button to the container using `aria-controls` and represented its state with `aria-expanded`. Added a dynamic, contextual `aria-label` (e.g., "Hide [Title]") to the generic "[hide]" / "[show]" toggle button.
🎯 **Why**: To significantly improve the experience for users who rely on screen readers. Previously, the button only announced "show" or "hide" without context of *what* it was showing or hiding, and there was no programmatic linkage or state representation between the toggle and the content.
📸 **Before/After**: Visually identical, but functionally superior for a11y.
♿ **Accessibility**: Added `aria-expanded`, `aria-controls`, and `aria-label` mapped via a unique `id` generated by React's `useId`.

---
*PR created automatically by Jules for task [8743243596259590829](https://jules.google.com/task/8743243596259590829) started by @aicoder2009*