### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in Markdown parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The application was passing unvalidated HTML variables, specifically `citation.formattedHtml`, to React's `dangerouslySetInnerHTML` prop in multiple components (`src/components/wiki/sortable-citation.tsx`, `src/app/cite/page.tsx`, `src/app/share/[code]/page.tsx`).
 **Learning:** This is a classic pattern for Cross-Site Scripting (XSS). If a citation's contents originated from an untrusted source or were maliciously formatted, an attacker could execute arbitrary scripts in a user's session when the citation is rendered.
 **Prevention:** Always sanitize any untrusted or dynamic HTML before rendering it in React. In a Next.js (SSR) application, use a library like `isomorphic-dompurify` to safely strip malicious scripts from the HTML payload on both the client and server side without hydration errors.
+
+## 2025-02-28 - [XSS via unsanitized marked output]
+**Vulnerability:** The application was using the `marked` library to parse Markdown content and passing the raw output to React's `dangerouslySetInnerHTML` prop in `src/app/docs/changelog/page.tsx` and `src/lib/docs.ts` without sanitization.
+**Learning:** The `marked` library does not sanitize HTML by default. This is a common pattern for Cross-Site Scripting (XSS). If a GitHub release body or a Markdown file contained malicious scripts, an attacker could execute arbitrary scripts in a user's session.
+**Prevention:** Always sanitize the output of `marked` using a library like `isomorphic-dompurify` (e.g., `DOMPurify.sanitize()`) before rendering it via `dangerouslySetInnerHTML` to safely strip malicious scripts from the HTML payload.

--- a/src/app/docs/changelog/page.tsx
+++ b/src/app/docs/changelog/page.tsx
@@ -1,6 +1,7 @@
 import { WikiBreadcrumbs } from "@/components/wiki/wiki-breadcrumbs";
 import { getGitHubReleases, getGitHubCommits } from "@/lib/github";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export const metadata = { title: "Changelog — OpenCitation" };
 
@@ -91,7 +92,7 @@ export default async function ChangelogPage() {
               {release.body ? (
                 <div
                   className="docs-content px-4 py-4"
-                  dangerouslySetInnerHTML={{ __html: marked(release.body) as string }}
+                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked(release.body) as string) }}
                 />
               ) : (
                 <p className="px-4 py-4 text-sm text-wiki-text-muted italic">No release notes.</p>

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,9 +1,10 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export async function getDocContent(slug: string): Promise<string> {
   const filePath = join(process.cwd(), "docs/content", `${slug}.md`);
   const markdown = readFileSync(filePath, "utf-8");
-  return await marked(markdown);
+  return DOMPurify.sanitize(await marked(markdown));
 }


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The application was using the `marked` library to parse Markdown content for GitHub releases and local docs. The unvalidated HTML output of `marked` was directly passed to React's `dangerouslySetInnerHTML` in `src/app/docs/changelog/page.tsx` and `src/lib/docs.ts`. This poses a significant XSS risk if the release descriptions or Markdown files contain malicious scripts.
🎯 **Impact**: An attacker who can manipulate a GitHub release description or local Markdown documentation could execute arbitrary JavaScript within a user's session when they visit the Changelog or documentation pages.
🔧 **Fix**: Added `DOMPurify.sanitize()` (from the `isomorphic-dompurify` package) to wrap the output of `marked()` before applying it to `dangerouslySetInnerHTML`.
✅ **Verification**: Code review verified changes. Ran `pnpm lint` and `pnpm test` successfully. Verified that `<script>` and `onload` handlers within parsed markdown will now be stripped. Added a journal entry to `.jules/sentinel.md` documenting the vulnerability and fix.

---
*PR created automatically by Jules for task [11370331060437349200](https://jules.google.com/task/11370331060437349200) started by @aicoder2009*