### PR TITLE
🎨 Palette: Improve accessibility of WikiCollapsible toggle button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-07 - Contextual Labels for Generic Text
+**Learning:** Adding contextual `aria-label` attributes (like 'Hide [Title]') to buttons with generic visual text (such as '[hide]' or '[show]') ensures screen reader users have proper context when navigating by controls. Mapping interactive widget states with `useId` for `aria-controls` and `aria-expanded` further improves accessibility by preventing ID collisions and providing clear feedback.
+**Action:** Always provide a contextual `aria-label` for buttons with generic text and use `useId` to manage interactive state attributes like `aria-controls` and `aria-expanded`.

--- a/src/components/wiki/wiki-collapsible.tsx
+++ b/src/components/wiki/wiki-collapsible.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useId } from "react";
 
 interface WikiCollapsibleProps {
   title: string;
@@ -14,6 +14,7 @@ export function WikiCollapsible({
   defaultOpen = true,
 }: WikiCollapsibleProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const contentId = useId();
 
   return (
     <div className="border border-wiki-border-light bg-wiki-offwhite">
@@ -22,11 +23,18 @@ export function WikiCollapsible({
         <button
           onClick={() => setIsOpen(!isOpen)}
           className="text-wiki-link text-sm hover:underline"
+          aria-expanded={isOpen}
+          aria-controls={contentId}
+          aria-label={`${isOpen ? "Hide" : "Show"} ${title}`}
         >
           [{isOpen ? "hide" : "show"}]
         </button>
       </div>
-      {isOpen && <div className="px-4 py-3">{children}</div>}
+      {isOpen && (
+        <div id={contentId} className="px-4 py-3">
+          {children}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Improved accessibility and semantic structure for the `WikiCollapsible` component, providing better context for screen readers and keyboard navigation users. Recorded UX learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [5326639634849020422](https://jules.google.com/task/5326639634849020422) started by @aicoder2009*