### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in Markdown parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The application was passing unvalidated HTML variables, specifically `citation.formattedHtml`, to React's `dangerouslySetInnerHTML` prop in multiple components (`src/components/wiki/sortable-citation.tsx`, `src/app/cite/page.tsx`, `src/app/share/[code]/page.tsx`).
 **Learning:** This is a classic pattern for Cross-Site Scripting (XSS). If a citation's contents originated from an untrusted source or were maliciously formatted, an attacker could execute arbitrary scripts in a user's session when the citation is rendered.
 **Prevention:** Always sanitize any untrusted or dynamic HTML before rendering it in React. In a Next.js (SSR) application, use a library like `isomorphic-dompurify` to safely strip malicious scripts from the HTML payload on both the client and server side without hydration errors.
+
+## 2026-05-07 - [XSS via Unsanitized Markdown Parsing]
+**Vulnerability:** The application was using the `marked` library to parse Markdown content and passing the raw HTML output directly to `dangerouslySetInnerHTML` in `src/app/docs/changelog/page.tsx` and rendering it through `src/lib/docs.ts`.
+**Learning:** The `marked` library does not sanitize HTML by default. If the Markdown content (e.g., from GitHub releases or local files) contains malicious HTML or scripts, it will be executed when rendered by React, leading to a Cross-Site Scripting (XSS) vulnerability.
+**Prevention:** Always wrap the output of Markdown parsers like `marked` with a sanitizer such as `DOMPurify` (using `isomorphic-dompurify` for SSR compatibility) before passing it to `dangerouslySetInnerHTML`.

--- a/src/app/docs/changelog/page.tsx
+++ b/src/app/docs/changelog/page.tsx
@@ -1,6 +1,7 @@
 import { WikiBreadcrumbs } from "@/components/wiki/wiki-breadcrumbs";
 import { getGitHubReleases, getGitHubCommits } from "@/lib/github";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export const metadata = { title: "Changelog — OpenCitation" };
 
@@ -91,7 +92,8 @@ export default async function ChangelogPage() {
               {release.body ? (
                 <div
                   className="docs-content px-4 py-4"
-                  dangerouslySetInnerHTML={{ __html: marked(release.body) as string }}
+                  // Sanitize the HTML output from marked to prevent XSS vulnerabilities
+                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked(release.body) as string) }}
                 />
               ) : (
                 <p className="px-4 py-4 text-sm text-wiki-text-muted italic">No release notes.</p>

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export async function getDocContent(slug: string): Promise<string> {
   const filePath = join(process.cwd(), "docs/content", `${slug}.md`);
   const markdown = readFileSync(filePath, "utf-8");
-  return await marked(markdown);
+  // Sanitize the HTML output from marked to prevent XSS vulnerabilities
+  return DOMPurify.sanitize(await marked(markdown));
 }


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The application was using the `marked` library to parse Markdown content and passing the raw HTML output directly to `dangerouslySetInnerHTML` in `src/app/docs/changelog/page.tsx` and returning it directly through `src/lib/docs.ts`. The `marked` library does not sanitize HTML by default. If the Markdown content (e.g., from GitHub releases or local files) contains malicious HTML or scripts, it will be executed when rendered by React, leading to a Cross-Site Scripting (XSS) vulnerability.
🎯 **Impact**: Malicious payloads could be injected via malicious markdown contents from github releases to compromise user security.
🔧 **Fix**: Wrapped the HTML output of `marked()` with a sanitizer `DOMPurify.sanitize()` (via `isomorphic-dompurify` for SSR compatibility) before passing it to `dangerouslySetInnerHTML` in `src/app/docs/changelog/page.tsx` and returning it from `getDocContent()` in `src/lib/docs.ts`.
✅ **Verification**: Verified using `pnpm lint` and `pnpm test`. Documented pattern to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [11382393232705371494](https://jules.google.com/task/11382393232705371494) started by @aicoder2009*