### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in Markdown rendering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The application was passing unvalidated HTML variables, specifically `citation.formattedHtml`, to React's `dangerouslySetInnerHTML` prop in multiple components (`src/components/wiki/sortable-citation.tsx`, `src/app/cite/page.tsx`, `src/app/share/[code]/page.tsx`).
 **Learning:** This is a classic pattern for Cross-Site Scripting (XSS). If a citation's contents originated from an untrusted source or were maliciously formatted, an attacker could execute arbitrary scripts in a user's session when the citation is rendered.
 **Prevention:** Always sanitize any untrusted or dynamic HTML before rendering it in React. In a Next.js (SSR) application, use a library like `isomorphic-dompurify` to safely strip malicious scripts from the HTML payload on both the client and server side without hydration errors.
+
+## 2025-02-28 - [XSS via marked() and dangerouslySetInnerHTML in Docs]
+**Vulnerability:** The application was parsing external markdown files (e.g. GitHub release notes in changelog) using `marked()` and passing the raw output directly into React's `dangerouslySetInnerHTML`.
+**Learning:** `marked()` does not sanitize HTML by default. Content pulled from external APIs or potentially modifiable sources poses an XSS risk if rendered directly, even if it "looks" like safe markdown.
+**Prevention:** Whenever parsing markdown to HTML (especially with `marked`), always sanitize the resulting HTML output using `isomorphic-dompurify` before passing it to `dangerouslySetInnerHTML`.

--- a/src/app/docs/changelog/page.tsx
+++ b/src/app/docs/changelog/page.tsx
@@ -1,6 +1,7 @@
 import { WikiBreadcrumbs } from "@/components/wiki/wiki-breadcrumbs";
 import { getGitHubReleases, getGitHubCommits } from "@/lib/github";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export const metadata = { title: "Changelog — OpenCitation" };
 
@@ -91,7 +92,7 @@ export default async function ChangelogPage() {
               {release.body ? (
                 <div
                   className="docs-content px-4 py-4"
-                  dangerouslySetInnerHTML={{ __html: marked(release.body) as string }}
+                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked(release.body) as string) }}
                 />
               ) : (
                 <p className="px-4 py-4 text-sm text-wiki-text-muted italic">No release notes.</p>

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,9 +1,10 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export async function getDocContent(slug: string): Promise<string> {
   const filePath = join(process.cwd(), "docs/content", `${slug}.md`);
   const markdown = readFileSync(filePath, "utf-8");
-  return await marked(markdown);
+  return DOMPurify.sanitize(await marked(markdown));
 }


### PR DESCRIPTION
## 🚨 Vulnerability
The application was parsing external markdown files (e.g. GitHub release notes in changelog) using `marked()` and passing the raw output directly into React's `dangerouslySetInnerHTML`.

## 💡 Learning & Impact
`marked()` does not sanitize HTML by default. Content pulled from external APIs or potentially modifiable sources poses an XSS risk if rendered directly, even if it "looks" like safe markdown. An attacker could potentially inject malicious scripts via a GitHub release body.

## 🔧 Fix
Wrapped the output of `marked()` with `DOMPurify.sanitize()` using the `isomorphic-dompurify` library (which is already an existing dependency for the Next.js app) before it gets set in `dangerouslySetInnerHTML`.

## ✅ Verification
1. Ensured the tests passed successfully (`pnpm test`).
2. Confirmed the frontend builds successfully (`pnpm build`).
3. Verified the changes locally to make sure Markdown output is appropriately sanitized.

---
*PR created automatically by Jules for task [4767459614626163323](https://jules.google.com/task/4767459614626163323) started by @aicoder2009*