### PR TITLE
🎨 Palette: Add contextual ARIA labels to wiki-collapsible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-08 - Added Contextual ARIA labels to Generic Buttons
+**Learning:** Found that generic visual button text like "[hide]" or "[show]" lacks context for screen reader users when navigating interactively (e.g., using a wiki-collapsible).
+**Action:** When creating toggle buttons or collapsible content with generic visual text, always add a contextual `aria-label` (e.g. `Show [Title]`) and map state with `aria-expanded` and `aria-controls` using `useId`.

--- a/src/components/wiki/wiki-collapsible.tsx
+++ b/src/components/wiki/wiki-collapsible.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useId } from "react";
 
 interface WikiCollapsibleProps {
   title: string;
@@ -14,6 +14,7 @@ export function WikiCollapsible({
   defaultOpen = true,
 }: WikiCollapsibleProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const contentId = useId();
 
   return (
     <div className="border border-wiki-border-light bg-wiki-offwhite">
@@ -22,11 +23,18 @@ export function WikiCollapsible({
         <button
           onClick={() => setIsOpen(!isOpen)}
           className="text-wiki-link text-sm hover:underline"
+          aria-expanded={isOpen}
+          aria-controls={contentId}
+          aria-label={`${isOpen ? "Hide" : "Show"} ${title}`}
         >
           [{isOpen ? "hide" : "show"}]
         </button>
       </div>
-      {isOpen && <div className="px-4 py-3">{children}</div>}
+      {isOpen && (
+        <div id={contentId} className="px-4 py-3">
+          {children}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
🎨 Palette: Add contextual ARIA labels to wiki-collapsible

💡 What: Added `useId` and contextual ARIA properties (`aria-controls`, `aria-expanded`, `aria-label`) to the toggle button in the `WikiCollapsible` component.
🎯 Why: Generic visual text like "[hide]" or "[show]" lacks context for screen reader users when navigating interactively. Linking the button to the content with a unique ID and providing a contextual label based on the `title` prop significantly improves usability.
♿ Accessibility:
  - Added a unique `id` to the collapsible content via `useId()`.
  - Added `aria-controls` to the toggle button, pointing to the content `id`.
  - Added `aria-expanded` reflecting the `isOpen` state.
  - Added a contextual `aria-label` (e.g. `Show [Title]`) to clarify what is being toggled.

---
*PR created automatically by Jules for task [2704451762723197622](https://jules.google.com/task/2704451762723197622) started by @aicoder2009*