### PR TITLE
🎨 Palette: Improve WikiCollapsible accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-08 - Accessible Collapsibles and Contextual Buttons
+**Learning:** Generic visual button text like "[hide]" or "[show]" lacks context for screen reader users when navigating by controls. Additionally, interactive collapsible widgets require ARIA mappings (`aria-expanded`, `aria-controls`) to correctly communicate state. Using React's `useId` provides collision-free IDs for mapping `aria-controls` to the content container.
+**Action:** Always provide a contextual `aria-label` (e.g., "Hide [Title]") for buttons with generic text. Use `useId` for mapping `aria-controls` to content IDs in reusable interactive components like tabs or collapsibles, and reflect state with `aria-expanded`.

--- a/src/components/wiki/wiki-collapsible.tsx
+++ b/src/components/wiki/wiki-collapsible.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useId } from "react";
 
 interface WikiCollapsibleProps {
   title: string;
@@ -14,6 +14,7 @@ export function WikiCollapsible({
   defaultOpen = true,
 }: WikiCollapsibleProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const contentId = useId();
 
   return (
     <div className="border border-wiki-border-light bg-wiki-offwhite">
@@ -22,11 +23,14 @@ export function WikiCollapsible({
         <button
           onClick={() => setIsOpen(!isOpen)}
           className="text-wiki-link text-sm hover:underline"
+          aria-expanded={isOpen}
+          aria-controls={contentId}
+          aria-label={`${isOpen ? "Hide" : "Show"} ${title}`}
         >
           [{isOpen ? "hide" : "show"}]
         </button>
       </div>
-      {isOpen && <div className="px-4 py-3">{children}</div>}
+      {isOpen && <div id={contentId} className="px-4 py-3">{children}</div>}
     </div>
   );
 }


### PR DESCRIPTION
💡 **What**: Added comprehensive accessibility attributes (`aria-expanded`, `aria-controls`, `aria-label`) to the `WikiCollapsible` component, leveraging React's `useId` for collision-free mappings.
🎯 **Why**: Generic visual button text like "[hide]" or "[show]" lacks context for screen reader users navigating by controls. Interactive collapsible widgets also require ARIA mappings to properly communicate state changes and content relationships.
📸 **Before/After**: Visually, the component looks completely unchanged. The improvements are entirely semantic/structural for screen readers.
♿ **Accessibility**: Screen readers can now correctly announce the component's state, associate the toggle button with its content, and provide contextual labels for what the button does ("Hide Contents" vs. just "[hide]").
📋 **Verification**: UI verified visually to assure no regressions in the presentation. Linter and tests run without errors. Learnings logged to `.jules/palette.md`.

---
*PR created automatically by Jules for task [4570286106840994186](https://jules.google.com/task/4570286106840994186) started by @aicoder2009*