### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS via unsanitized dangerouslySetInnerHTML from marked

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The application was passing unvalidated HTML variables, specifically `citation.formattedHtml`, to React's `dangerouslySetInnerHTML` prop in multiple components (`src/components/wiki/sortable-citation.tsx`, `src/app/cite/page.tsx`, `src/app/share/[code]/page.tsx`).
 **Learning:** This is a classic pattern for Cross-Site Scripting (XSS). If a citation's contents originated from an untrusted source or were maliciously formatted, an attacker could execute arbitrary scripts in a user's session when the citation is rendered.
 **Prevention:** Always sanitize any untrusted or dynamic HTML before rendering it in React. In a Next.js (SSR) application, use a library like `isomorphic-dompurify` to safely strip malicious scripts from the HTML payload on both the client and server side without hydration errors.
+
+## 2025-05-08 - [XSS via unsanitized dangerouslySetInnerHTML from marked]
+**Vulnerability:** The application was passing unvalidated HTML variables returned by `marked` to React's `dangerouslySetInnerHTML` prop in multiple components like `src/app/docs/changelog/page.tsx` and `src/lib/docs.ts`.
+**Learning:** `marked` does not sanitize HTML by default. If a markdown source (like GitHub release notes) contains malicious HTML payloads, it can execute arbitrary scripts via `dangerouslySetInnerHTML`.
+**Prevention:** Always sanitize any untrusted or dynamic HTML before rendering it in React. Wrap the `marked` library output with `DOMPurify.sanitize()` using a library like `isomorphic-dompurify`.

--- a/src/app/docs/changelog/page.tsx
+++ b/src/app/docs/changelog/page.tsx
@@ -1,6 +1,7 @@
 import { WikiBreadcrumbs } from "@/components/wiki/wiki-breadcrumbs";
 import { getGitHubReleases, getGitHubCommits } from "@/lib/github";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export const metadata = { title: "Changelog — OpenCitation" };
 
@@ -91,7 +92,7 @@ export default async function ChangelogPage() {
               {release.body ? (
                 <div
                   className="docs-content px-4 py-4"
-                  dangerouslySetInnerHTML={{ __html: marked(release.body) as string }}
+                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked(release.body) as string) }}
                 />
               ) : (
                 <p className="px-4 py-4 text-sm text-wiki-text-muted italic">No release notes.</p>

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export async function getDocContent(slug: string): Promise<string> {
   const filePath = join(process.cwd(), "docs/content", `${slug}.md`);
   const markdown = readFileSync(filePath, "utf-8");
-  return await marked(markdown);
+  const rawHtml = await marked(markdown);
+  return DOMPurify.sanitize(rawHtml);
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application was passing unvalidated HTML variables returned by the `marked` library to React's `dangerouslySetInnerHTML` prop in multiple components (`src/app/docs/changelog/page.tsx` and `src/lib/docs.ts`). `marked` does not sanitize HTML by default.
🎯 **Impact:** If a markdown source (like GitHub release notes or external markdown files) contained malicious HTML payloads, it could execute arbitrary scripts via `dangerouslySetInnerHTML` when the page is rendered (Cross-Site Scripting - XSS).
🔧 **Fix:** Wrapped the output of `marked()` with `DOMPurify.sanitize()` from the existing `isomorphic-dompurify` library before rendering the HTML.
✅ **Verification:** Verified by checking that `pnpm build` and `pnpm test` pass. The tests and linting check that `DOMPurify` properly integrates with the build system.

---
*PR created automatically by Jules for task [4864979850147563242](https://jules.google.com/task/4864979850147563242) started by @aicoder2009*