### PR TITLE
⚡ Bolt: Concurrent data fetching in GET /api/share

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-09 - Concurrent Data Fetching for Related Collections
+**Learning:** In APIs that fetch related but independent top-level entities for a user (such as fetching user shares alongside their lists and projects to enrich the response), fetching them sequentially causes unnecessary waterfall latency, blocking subsequent queries on the resolution of earlier, unrelated ones.
+**Action:** Always utilize `Promise.all` to fetch independent data collections concurrently (e.g. `[shares, lists, projects] = await Promise.all([listUserShares(userId), getUserLists(userId), getUserProjects(userId)])`) to minimize overall TTFB (Time to First Byte) latency for database interactions.

--- a/src/app/api/share/route.ts
+++ b/src/app/api/share/route.ts
@@ -22,11 +22,14 @@ export async function GET() {
       );
     }
 
-    const shares = await listUserShares(userId);
+    // Fetch shares, lists, and projects concurrently to minimize database latency.
+    const [shares, lists, projects] = await Promise.all([
+      listUserShares(userId),
+      getUserLists(userId),
+      getUserProjects(userId),
+    ]);
 
     // Enrich with target name so the UI can render without extra round-trips.
-    const lists = await getUserLists(userId);
-    const projects = await getUserProjects(userId);
     const listById = new Map(lists.map((l) => [l.id, l]));
     const projectById = new Map(projects.map((p) => [p.id, p]));
 


### PR DESCRIPTION
💡 **What**: Optimized the data fetching logic in `GET /api/share` (inside `src/app/api/share/route.ts`) to fetch user shares, lists, and projects concurrently rather than sequentially.
🎯 **Why**: The endpoint was executing three independent database requests in sequence: `listUserShares(userId)`, `getUserLists(userId)`, and `getUserProjects(userId)`. Because the second and third queries did not depend on the outcome of the first, sequentially awaiting them caused unnecessary waterfall latency.
📊 **Impact**: Reduces Time to First Byte (TTFB) and overall API latency by performing 3 concurrent I/O operations instead of 3 sequential operations, cutting database waiting time roughly to the time of the longest single query.
🔬 **Measurement**: Verify by running `pnpm test:run` to ensure all tests still pass and no logic/behavior has changed, and deploy to observe reduced P99 latency in APM for this endpoint.

Additionally, this adds the `Promise.all` best practice to the `.jules/bolt.md` performance journal.

---
*PR created automatically by Jules for task [13646019774705997302](https://jules.google.com/task/13646019774705997302) started by @aicoder2009*