### PR TITLE
🎨 Palette: Make WikiCollapsible accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+## 2024-05-09 - Generic Visual Labels Need Contextual ARIA
+
+**Learning:** When using generic visual text for buttons (like "[hide]" or "[show]" in custom collapsible widgets), screen reader users lack context on *what* is being hidden or shown, especially when navigating by controls. Also, for interactive toggle widgets, `aria-controls` mapped to a unique ID (via `useId`) and `aria-expanded` reflecting the current state are necessary so screen readers announce the element as a proper toggle.
+
+**Action:** Always provide a contextual `aria-label` (e.g., `Hide ${title}`) on buttons with generic visual text, and ensure proper widget state attributes (`aria-expanded`, `aria-controls`) are mapped to a unique ID.

--- a/src/components/wiki/wiki-collapsible.tsx
+++ b/src/components/wiki/wiki-collapsible.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useId } from "react";
 
 interface WikiCollapsibleProps {
   title: string;
@@ -14,6 +14,7 @@ export function WikiCollapsible({
   defaultOpen = true,
 }: WikiCollapsibleProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const contentId = useId();
 
   return (
     <div className="border border-wiki-border-light bg-wiki-offwhite">
@@ -21,12 +22,19 @@ export function WikiCollapsible({
         <span className="font-medium text-sm">{title}</span>
         <button
           onClick={() => setIsOpen(!isOpen)}
+          aria-expanded={isOpen}
+          aria-controls={contentId}
+          aria-label={`${isOpen ? "Hide" : "Show"} ${title}`}
           className="text-wiki-link text-sm hover:underline"
         >
           [{isOpen ? "hide" : "show"}]
         </button>
       </div>
-      {isOpen && <div className="px-4 py-3">{children}</div>}
+      {isOpen && (
+        <div id={contentId} className="px-4 py-3">
+          {children}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
**What:**
Added proper ARIA attributes to `WikiCollapsible`'s toggle button.

**Why:**
The component used generic visual text ("[hide]" / "[show]") which lacks context for screen reader users when navigating by control. Without `aria-expanded` and `aria-controls`, screen readers wouldn't announce the button as an interactive toggle, nor clearly describe what it controls.

**Accessibility Improvements:**
- Added React's `useId` to generate a robust, unique ID for the content container.
- Added `aria-controls` mapped to the generated ID to programmatically link the button and the content.
- Added `aria-expanded` to reflect the open/closed state.
- Added a contextual `aria-label` (e.g., "Hide [Title]") to give screen reader users meaningful context.

---
*PR created automatically by Jules for task [3365539434910934183](https://jules.google.com/task/3365539434910934183) started by @aicoder2009*