### PR TITLE
🎨 Palette: Improve WikiCollapsible accessibility with proper ARIA attributes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-09 - Accessible Collapsibles and Contextual Labels
+**Learning:** For accessible React interactive widgets (like tabs or collapsibles), it's crucial to use React's `useId` hook to generate unique IDs for `aria-controls` mappings to ensure correct screen reader context without ID collisions. Additionally, buttons that use generic visual text (like "[hide]" or "[show]") must provide a contextual `aria-label` (e.g., 'Hide Contents') so that screen reader users have proper context when navigating by controls.
+**Action:** Always verify that custom interactive components use `useId` for mapping `aria-controls` to content areas, and verify that generic visual buttons have sufficiently descriptive `aria-label` attributes.

--- a/src/components/wiki/wiki-collapsible.tsx
+++ b/src/components/wiki/wiki-collapsible.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useId } from "react";
 
 interface WikiCollapsibleProps {
   title: string;
@@ -14,6 +14,7 @@ export function WikiCollapsible({
   defaultOpen = true,
 }: WikiCollapsibleProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const contentId = useId();
 
   return (
     <div className="border border-wiki-border-light bg-wiki-offwhite">
@@ -22,11 +23,18 @@ export function WikiCollapsible({
         <button
           onClick={() => setIsOpen(!isOpen)}
           className="text-wiki-link text-sm hover:underline"
+          aria-expanded={isOpen}
+          aria-controls={contentId}
+          aria-label={`${isOpen ? "Hide" : "Show"} ${title}`}
         >
           [{isOpen ? "hide" : "show"}]
         </button>
       </div>
-      {isOpen && <div className="px-4 py-3">{children}</div>}
+      {isOpen && (
+        <div id={contentId} className="px-4 py-3">
+          {children}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### 💡 What:
Added missing ARIA attributes (`aria-expanded`, `aria-controls`, and `aria-label`) to the `WikiCollapsible` component's toggle button, using React's `useId` to reliably map the button to the content container.

### 🎯 Why:
The `WikiCollapsible` component previously relied solely on the generic visual text "[hide]" or "[show]". This lacked context for screen reader users when navigating by buttons. The addition of `aria-expanded` and specific labels like "Hide Contents" provides crucial context, making the interface significantly more accessible and intuitive without altering its visual layout.

### ♿ Accessibility:
- Added `aria-expanded` to reflect the open/closed state.
- Utilized `useId` to dynamically create a `contentId` and linked it via `aria-controls` to the content container.
- Implemented a dynamic `aria-label` (e.g., "Hide [Title]") to replace the generic "[hide]/[show]" text.

---
*PR created automatically by Jules for task [761150868708088405](https://jules.google.com/task/761150868708088405) started by @aicoder2009*