### PR TITLE
🛡️ Sentinel: [HIGH] Fix Cross-Site Scripting (XSS) in Markdown rendering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The application was passing unvalidated HTML variables, specifically `citation.formattedHtml`, to React's `dangerouslySetInnerHTML` prop in multiple components (`src/components/wiki/sortable-citation.tsx`, `src/app/cite/page.tsx`, `src/app/share/[code]/page.tsx`).
 **Learning:** This is a classic pattern for Cross-Site Scripting (XSS). If a citation's contents originated from an untrusted source or were maliciously formatted, an attacker could execute arbitrary scripts in a user's session when the citation is rendered.
 **Prevention:** Always sanitize any untrusted or dynamic HTML before rendering it in React. In a Next.js (SSR) application, use a library like `isomorphic-dompurify` to safely strip malicious scripts from the HTML payload on both the client and server side without hydration errors.
+
+## 2025-02-13 - [HIGH] XSS Vulnerability in Markdown Rendering
+**Vulnerability:** External and internal markdown contents (e.g. documentation, GitHub release notes) were parsed to HTML using `marked` and directly injected into the DOM using `dangerouslySetInnerHTML` without any sanitization.
+**Learning:** By default, modern versions of `marked` (and many other markdown parsers) do not sanitize their output to prevent XSS. If user-generated content, or potentially tainted external API content like GitHub release notes, includes an arbitrary script like `<script>alert(1)</script>`, `marked` will output this payload unchanged.
+**Prevention:** Whenever rendering HTML output from `marked` (or any non-sanitizing parser) using `dangerouslySetInnerHTML`, always pass the resulting HTML through a sanitizer like `DOMPurify` (or `isomorphic-dompurify` on the server-side). E.g. `DOMPurify.sanitize(marked(input))`.

--- a/src/app/docs/changelog/page.tsx
+++ b/src/app/docs/changelog/page.tsx
@@ -1,6 +1,7 @@
 import { WikiBreadcrumbs } from "@/components/wiki/wiki-breadcrumbs";
 import { getGitHubReleases, getGitHubCommits } from "@/lib/github";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export const metadata = { title: "Changelog — OpenCitation" };
 
@@ -91,7 +92,7 @@ export default async function ChangelogPage() {
               {release.body ? (
                 <div
                   className="docs-content px-4 py-4"
-                  dangerouslySetInnerHTML={{ __html: marked(release.body) as string }}
+                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked(release.body) as string) }}
                 />
               ) : (
                 <p className="px-4 py-4 text-sm text-wiki-text-muted italic">No release notes.</p>

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,9 +1,10 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export async function getDocContent(slug: string): Promise<string> {
   const filePath = join(process.cwd(), "docs/content", `${slug}.md`);
   const markdown = readFileSync(filePath, "utf-8");
-  return await marked(markdown);
+  return DOMPurify.sanitize(await marked(markdown));
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Cross-Site Scripting (XSS) was possible via un-sanitized parsed Markdown HTML output. The application was piping the output of `marked()` directly into `dangerouslySetInnerHTML`.
🎯 **Impact:** Malicious actors could inject and execute arbitrary JavaScript (`<script>alert(1)</script>`) in the client's browser if the processed markdown payload contains XSS patterns.
🔧 **Fix:** Passed `marked()` output through `DOMPurify.sanitize()` (via the `isomorphic-dompurify` library) prior to usage with `dangerouslySetInnerHTML`.
✅ **Verification:** Ran test suite successfully. No unresolved linting errors tied to the modified files. Cleaned up scratchpads and lockfiles. Recorded Sentinel journal entry.

---
*PR created automatically by Jules for task [15953590320813776470](https://jules.google.com/task/15953590320813776470) started by @aicoder2009*