### PR TITLE
⚡ Bolt: Optimize project fetching with parallel requests

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-10 - Client-Side Waterfall Fetching in Detail Pages
+**Learning:** The codebase has an anti-pattern of sequential `await fetch()` calls on Detail pages (e.g., fetching project details, then its lists, then all user lists) which causes waterfall latency and significantly degrades Time to First Byte / load time for the client since these requests do not strictly depend on each other's responses.
+**Action:** When fetching independent data models on detail pages, always group them using `Promise.all` for both the network requests and the subsequent `.json()` parsing to execute them concurrently.

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -47,9 +47,20 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
     try {
       setIsLoading(true);
 
-      // Fetch project details
-      const projectResponse = await fetch(`/api/projects/${projectId}`);
-      const projectResult = await projectResponse.json();
+      // ⚡ Bolt: Optimize project fetching with parallel requests
+      // Execute all network requests concurrently to avoid waterfall latency
+      const [projectResponse, listsResponse, allListsResponse] = await Promise.all([
+        fetch(`/api/projects/${projectId}`),
+        fetch(`/api/projects/${projectId}/lists`),
+        fetch("/api/lists")
+      ]);
+
+      // Parse all JSON responses concurrently
+      const [projectResult, listsResult, allListsResult] = await Promise.all([
+        projectResponse.json(),
+        listsResponse.json(),
+        allListsResponse.json()
+      ]);
 
       if (!projectResult.success) {
         setError(projectResult.error || "Project not found");
@@ -60,17 +71,9 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setEditName(projectResult.data.name);
       setEditDescription(projectResult.data.description || "");
 
-      // Fetch lists in project
-      const listsResponse = await fetch(`/api/projects/${projectId}/lists`);
-      const listsResult = await listsResponse.json();
-
       if (listsResult.success) {
         setLists(listsResult.data);
       }
-
-      // Fetch all user lists (for adding to project)
-      const allListsResponse = await fetch("/api/lists");
-      const allListsResult = await allListsResponse.json();
 
       if (allListsResult.success) {
         setAllLists(allListsResult.data);


### PR DESCRIPTION
💡 What: The optimization implemented
Replaced three sequential `await fetch()` calls (project details, project lists, all user lists) and their subsequent `.json()` parsing with a single `Promise.all` block.

🎯 Why: The performance problem it solves
The previous implementation caused client-side "waterfall" latency. The browser had to wait for the project details request to finish before even starting the lists request, and had to wait for the lists request to finish before requesting all user lists. Because these three queries are independent and do not rely on each other's responses, making them wait for each other adds unnecessary latency to the page's Time to First Byte (TTFB).

📊 Impact: Expected performance improvement
Significantly reduces page load time and TTFB on the Project Detail view. The maximum network latency is now bottlenecked only by the single slowest request (typically project lists or details), rather than the sum of all three requests.

🔬 Measurement: How to verify the improvement
Inspect the Network tab in the browser dev tools when loading a project page (e.g., `/projects/123`). Previously, the three requests (`/api/projects/123`, `/api/projects/123/lists`, and `/api/lists`) would appear sequentially (stair-step pattern). Now, all three requests will be initiated concurrently.

---
*PR created automatically by Jules for task [5908938330888914389](https://jules.google.com/task/5908938330888914389) started by @aicoder2009*