### PR TITLE
🎨 Palette: Add ARIA labels to icon and generic text buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-10 - Missing ARIA Labels on Icon and Generic Buttons
+**Learning:** Found multiple instances where interactive buttons used either ambiguous icons (like `&times;`) or generic link-style bracketed text (like `[edit]`, `[copy]`) without any screen-reader accessible context. This is a common pattern in the wiki-style UI components.
+**Action:** Always add descriptive `aria-label` attributes to buttons that lack clear, unambiguous text content, specifically targeting icon-only close buttons and generic action links in lists to provide necessary context for assistive technologies.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -326,6 +326,7 @@ export default function LandingPage() {
                         </p>
                       </div>
                       <button
+                        aria-label="Copy recent citation"
                         onClick={() => copyRecentCitation(citation.formattedText)}
                         className="text-wiki-link text-sm hover:underline shrink-0"
                       >
@@ -440,7 +441,7 @@ export default function LandingPage() {
                   <span className="animate-bounce inline-block">↓</span> Scroll to read all sections
                 </p>
               </div>
-              <button onClick={() => setShowPrivacy(false)} className="text-wiki-text-muted hover:text-wiki-text text-2xl leading-none">&times;</button>
+              <button aria-label="Close" onClick={() => setShowPrivacy(false)} className="text-wiki-text-muted hover:text-wiki-text text-2xl leading-none">&times;</button>
             </div>
             <div className="p-4 text-sm space-y-4 pb-12 overflow-y-auto flex-1" style={{ scrollbarWidth: 'auto', scrollbarColor: '#aaa #f0f0f0' }}>
               <p><b>Last updated:</b> January 2025</p>
@@ -502,7 +503,7 @@ export default function LandingPage() {
                   <span className="animate-bounce inline-block">↓</span> Scroll to read all sections
                 </p>
               </div>
-              <button onClick={() => setShowTerms(false)} className="text-wiki-text-muted hover:text-wiki-text text-2xl leading-none">&times;</button>
+              <button aria-label="Close" onClick={() => setShowTerms(false)} className="text-wiki-text-muted hover:text-wiki-text text-2xl leading-none">&times;</button>
             </div>
             <div className="p-4 text-sm space-y-4 pb-12 overflow-y-auto flex-1" style={{ scrollbarWidth: 'auto', scrollbarColor: '#aaa #f0f0f0' }}>
               <p><b>Last updated:</b> January 2025</p>
@@ -569,7 +570,7 @@ export default function LandingPage() {
                 <h2 className="text-xl font-bold">Report an Issue</h2>
                 <p className="text-xs text-wiki-text-muted">Help us improve OpenCitation</p>
               </div>
-              <button onClick={closeReportModal} className="text-wiki-text-muted hover:text-wiki-text text-2xl leading-none">&times;</button>
+              <button aria-label="Close" onClick={closeReportModal} className="text-wiki-text-muted hover:text-wiki-text text-2xl leading-none">&times;</button>
             </div>
             <div className="p-4 overflow-y-auto flex-1" style={{ scrollbarWidth: 'auto', scrollbarColor: '#aaa #f0f0f0' }}>
               {/* Choice Screen */}

--- a/src/components/wiki/sortable-citation.tsx
+++ b/src/components/wiki/sortable-citation.tsx
@@ -195,6 +195,7 @@ export function SortableCitation({
         <button
           {...attributes}
           {...listeners}
+          aria-label="Drag to reorder"
           className="cursor-grab active:cursor-grabbing p-1 hover:bg-wiki-border-light rounded text-wiki-text-muted"
           title="Drag to reorder"
         >
@@ -334,6 +335,7 @@ export function SortableCitation({
             />
             <div className="flex flex-wrap gap-2 mb-3">
               <button
+                aria-label="Copy citation"
                 onClick={() => onCopy(citation.formattedText)}
                 className="text-wiki-link text-sm hover:underline"
               >
@@ -341,6 +343,7 @@ export function SortableCitation({
               </button>
               {citation.fields && (
                 <button
+                  aria-label="Copy in-text citation"
                   onClick={() =>
                     onCopy(
                       generateInTextCitation(
@@ -356,12 +359,14 @@ export function SortableCitation({
                 </button>
               )}
               <button
+                aria-label="Edit citation"
                 onClick={startEditing}
                 className="text-wiki-link text-sm hover:underline"
               >
                 [edit]
               </button>
               <button
+                aria-label="Delete citation"
                 onClick={() => onDelete(citation.id)}
                 className="text-wiki-link text-sm hover:underline"
               >
@@ -410,6 +415,7 @@ export function SortableCitation({
                 <div className="flex items-center gap-2 mb-1">
                   <span className="text-xs font-medium text-wiki-text-muted">Notes</span>
                   <button
+                    aria-label="Edit notes"
                     onClick={() => {
                       setNotesDraft(citation.notes ?? "");
                       setEditingNotes(true);
@@ -419,6 +425,7 @@ export function SortableCitation({
                     [edit]
                   </button>
                   <button
+                    aria-label="Clear notes"
                     onClick={() => onSaveNotes(citation.id, "")}
                     className="text-wiki-link text-xs hover:underline"
                   >
@@ -524,6 +531,7 @@ export function SortableCitation({
                     Quotes ({citation.quotes.length})
                   </span>
                   <button
+                    aria-label="Edit quotes"
                     onClick={() => {
                       setQuotesDraft(citation.quotes ?? []);
                       setEditingQuotes(true);
@@ -575,6 +583,7 @@ export function SortableCitation({
                     onClick={() => onRemoveTag(citation.id, tag)}
                     className="hover:text-wiki-link"
                     title="Remove tag"
+                    aria-label="Remove tag"
                   >
                     &times;
                   </button>
@@ -645,6 +654,7 @@ export function SortableCitation({
               </div>
             ) : (
               <button
+                aria-label="Add tag"
                 onClick={() => setEditingTagsId(citation.id)}
                 className="text-wiki-link text-xs hover:underline"
               >


### PR DESCRIPTION
Added `aria-label` attributes to multiple interactive elements across the application to improve screen reader accessibility. This includes:

- Adding labels to the "Close" (`&times;`) buttons on modal dialogues (Privacy, Terms, Bug Report).
- Adding labels to generic, repeating list actions (`[copy]`, `[edit]`, `[delete]`, `[clear]`) in citation and recent lists to give clearer context.
- Adding a descriptive label to the drag handle button.

No visual or functional changes were introduced.

---
*PR created automatically by Jules for task [13184899070219643157](https://jules.google.com/task/13184899070219643157) started by @aicoder2009*