### PR TITLE
🎨 Palette: Add ARIA accessibility to WikiCollapsible component

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-10 - ARIA context for generic visual text buttons
+**Learning:** The `WikiCollapsible` component used generic text `[hide]` and `[show]` for its toggle button, which lacks context when read by a screen reader (especially out of context). Additionally, interactive collapsibles require `aria-expanded` and `aria-controls` to properly announce their state and associate the control with the collapsible content.
+**Action:** Always provide a contextual `aria-label` (e.g., `"Hide [Title]"`) for buttons using generic visual text. Use React's `useId` to link `aria-controls` on the button to the `id` of the collapsible content, and ensure `aria-expanded` accurately reflects the current state to support screen reader users.

--- a/src/components/wiki/wiki-collapsible.tsx
+++ b/src/components/wiki/wiki-collapsible.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useId } from "react";
 
 interface WikiCollapsibleProps {
   title: string;
@@ -14,6 +14,7 @@ export function WikiCollapsible({
   defaultOpen = true,
 }: WikiCollapsibleProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const contentId = useId();
 
   return (
     <div className="border border-wiki-border-light bg-wiki-offwhite">
@@ -22,11 +23,18 @@ export function WikiCollapsible({
         <button
           onClick={() => setIsOpen(!isOpen)}
           className="text-wiki-link text-sm hover:underline"
+          aria-expanded={isOpen}
+          aria-controls={isOpen ? contentId : undefined}
+          aria-label={`${isOpen ? "Hide" : "Show"} ${title}`}
         >
           [{isOpen ? "hide" : "show"}]
         </button>
       </div>
-      {isOpen && <div className="px-4 py-3">{children}</div>}
+      {isOpen && (
+        <div id={contentId} className="px-4 py-3">
+          {children}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
🎨 **Palette: Add ARIA accessibility to WikiCollapsible component**

💡 **What:** Added comprehensive ARIA accessibility attributes (`aria-controls`, `aria-expanded`, and `aria-label`) to the `WikiCollapsible` toggle button, using React's `useId` to reliably link controls.

🎯 **Why:** The component used generic visual text `[hide]` and `[show]` for its toggle button, which lacks context when read by a screen reader (especially out of context or via rotor menus). Additionally, interactive collapsibles require `aria-expanded` and `aria-controls` to properly announce their state and associate the control with the collapsible content area for screen reader users.

♿ **Accessibility:**
* Added contextual `aria-label` using the collapsible title.
* Added `aria-expanded` to reflect current state.
* Added `aria-controls` linked to a unique `id` on the content container using React's `useId`.

_Visual appearance remains completely unchanged. Checked with passing test suites and frontend verification routines._

---
*PR created automatically by Jules for task [12678422003932050755](https://jules.google.com/task/12678422003932050755) started by @aicoder2009*