### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in markdown rendering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The application was passing unvalidated HTML variables, specifically `citation.formattedHtml`, to React's `dangerouslySetInnerHTML` prop in multiple components (`src/components/wiki/sortable-citation.tsx`, `src/app/cite/page.tsx`, `src/app/share/[code]/page.tsx`).
 **Learning:** This is a classic pattern for Cross-Site Scripting (XSS). If a citation's contents originated from an untrusted source or were maliciously formatted, an attacker could execute arbitrary scripts in a user's session when the citation is rendered.
 **Prevention:** Always sanitize any untrusted or dynamic HTML before rendering it in React. In a Next.js (SSR) application, use a library like `isomorphic-dompurify` to safely strip malicious scripts from the HTML payload on both the client and server side without hydration errors.
+
+## 2024-05-10 - XSS Vulnerability in Markdown Rendering
+**Vulnerability:** Cross-Site Scripting (XSS) vulnerability via un-sanitized Markdown output from `marked` being passed into `dangerouslySetInnerHTML`.
+**Learning:** By default, the `marked` library in this project returns raw, potentially malicious HTML. It does not sanitize the input. Passing its output directly to React's `dangerouslySetInnerHTML` exposes the application to XSS attacks.
+**Prevention:** Always wrap the output of `marked` (or any markdown parser) with `DOMPurify.sanitize()` (using `isomorphic-dompurify` for server-side compatibility) before rendering it using `dangerouslySetInnerHTML`.

--- a/src/app/docs/changelog/page.tsx
+++ b/src/app/docs/changelog/page.tsx
@@ -1,6 +1,7 @@
 import { WikiBreadcrumbs } from "@/components/wiki/wiki-breadcrumbs";
 import { getGitHubReleases, getGitHubCommits } from "@/lib/github";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export const metadata = { title: "Changelog — OpenCitation" };
 
@@ -91,7 +92,7 @@ export default async function ChangelogPage() {
               {release.body ? (
                 <div
                   className="docs-content px-4 py-4"
-                  dangerouslySetInnerHTML={{ __html: marked(release.body) as string }}
+                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked(release.body) as string) }}
                 />
               ) : (
                 <p className="px-4 py-4 text-sm text-wiki-text-muted italic">No release notes.</p>

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export async function getDocContent(slug: string): Promise<string> {
   const filePath = join(process.cwd(), "docs/content", `${slug}.md`);
   const markdown = readFileSync(filePath, "utf-8");
-  return await marked(markdown);
+  const html = await marked(markdown);
+  return DOMPurify.sanitize(html);
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Un-sanitized Markdown output from the `marked` library was being passed directly into React's `dangerouslySetInnerHTML`.
🎯 **Impact:** Exposes the application to Cross-Site Scripting (XSS) attacks. If an attacker controls the markdown input, they could inject malicious scripts.
🔧 **Fix:** Wrapped the output of `marked` with `DOMPurify.sanitize()` (using `isomorphic-dompurify` for server-side compatibility) before rendering it using `dangerouslySetInnerHTML` in `src/app/docs/changelog/page.tsx` and `src/lib/docs.ts`.
✅ **Verification:** Verified that XSS attack payloads are successfully stripped out while legitimate markdown elements remain formatted correctly. All unit tests passed without regressions.

---
*PR created automatically by Jules for task [16551963513175056125](https://jules.google.com/task/16551963513175056125) started by @aicoder2009*