### PR TITLE
🎨 Palette: Improve WikiCollapsible Accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2025-02-18 - Improve WikiCollapsible Accessibility
+**Learning:** Collapsible components without explicit `aria-expanded` and `aria-controls` attributes lack context for screen readers. Using `useId()` ensures unique IDs for `aria-controls` mapping. Providing contextual `aria-label`s like "Hide [Title]" or "Show [Title]" instead of generic visual text ensures screen reader users have proper context.
+**Action:** Always provide `aria-expanded`, `aria-controls`, and descriptive `aria-label`s for custom interactive widgets like collapsibles and accordions.

--- a/src/components/wiki/wiki-collapsible.tsx
+++ b/src/components/wiki/wiki-collapsible.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useId, useState } from "react";
 
 interface WikiCollapsibleProps {
   title: string;
@@ -14,6 +14,7 @@ export function WikiCollapsible({
   defaultOpen = true,
 }: WikiCollapsibleProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const contentId = useId();
 
   return (
     <div className="border border-wiki-border-light bg-wiki-offwhite">
@@ -21,12 +22,15 @@ export function WikiCollapsible({
         <span className="font-medium text-sm">{title}</span>
         <button
           onClick={() => setIsOpen(!isOpen)}
+          aria-expanded={isOpen}
+          aria-controls={contentId}
+          aria-label={isOpen ? `Hide ${title}` : `Show ${title}`}
           className="text-wiki-link text-sm hover:underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
         >
           [{isOpen ? "hide" : "show"}]
         </button>
       </div>
-      {isOpen && <div className="px-4 py-3">{children}</div>}
+      {isOpen && <div id={contentId} className="px-4 py-3">{children}</div>}
     </div>
   );
 }


### PR DESCRIPTION
I've improved the accessibility of the `WikiCollapsible` component by adding the proper `aria-expanded` and `aria-controls` attributes, and ensuring the toggle button has an explicit, contextual `aria-label` (e.g. "Hide Contents" or "Show Contents" instead of just "[hide]" or "[show]"). I've verified the changes work correctly visually and with the unit tests, and I have logged this specific accessibility learning in the Palette journal to enforce this pattern moving forward.

---
*PR created automatically by Jules for task [9198544780688034677](https://jules.google.com/task/9198544780688034677) started by @aicoder2009*