### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in markdown parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The application was passing unvalidated HTML variables, specifically `citation.formattedHtml`, to React's `dangerouslySetInnerHTML` prop in multiple components (`src/components/wiki/sortable-citation.tsx`, `src/app/cite/page.tsx`, `src/app/share/[code]/page.tsx`).
 **Learning:** This is a classic pattern for Cross-Site Scripting (XSS). If a citation's contents originated from an untrusted source or were maliciously formatted, an attacker could execute arbitrary scripts in a user's session when the citation is rendered.
 **Prevention:** Always sanitize any untrusted or dynamic HTML before rendering it in React. In a Next.js (SSR) application, use a library like `isomorphic-dompurify` to safely strip malicious scripts from the HTML payload on both the client and server side without hydration errors.
+
+## 2025-02-14 - Unsanitized Markdown Rendering (XSS Risk)
+**Vulnerability:** The application was using the `marked` library to parse markdown and then directly injecting the resulting HTML into React components via `dangerouslySetInnerHTML` in `src/app/docs/changelog/page.tsx` and `src/lib/docs.ts`, without any sanitization.
+**Learning:** `marked` does not sanitize HTML by default. If the markdown source is ever compromised (e.g., if a GitHub release contains a malicious payload, or if `docs/content` files are user-generated in the future), this would lead to a Cross-Site Scripting (XSS) vulnerability.
+**Prevention:** Always wrap the output of `marked()` with `DOMPurify.sanitize()` (using `isomorphic-dompurify` for SSR compatibility) before passing it to `dangerouslySetInnerHTML`.

--- a/src/app/docs/changelog/page.tsx
+++ b/src/app/docs/changelog/page.tsx
@@ -1,6 +1,7 @@
 import { WikiBreadcrumbs } from "@/components/wiki/wiki-breadcrumbs";
 import { getGitHubReleases, getGitHubCommits } from "@/lib/github";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export const metadata = { title: "Changelog — OpenCitation" };
 
@@ -91,7 +92,7 @@ export default async function ChangelogPage() {
               {release.body ? (
                 <div
                   className="docs-content px-4 py-4"
-                  dangerouslySetInnerHTML={{ __html: marked(release.body) as string }}
+                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked(release.body) as string) }}
                 />
               ) : (
                 <p className="px-4 py-4 text-sm text-wiki-text-muted italic">No release notes.</p>

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,9 +1,10 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export async function getDocContent(slug: string): Promise<string> {
   const filePath = join(process.cwd(), "docs/content", `${slug}.md`);
   const markdown = readFileSync(filePath, "utf-8");
-  return await marked(markdown);
+  return DOMPurify.sanitize(await marked(markdown));
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The application was using the `marked` library to parse markdown and then directly injecting the resulting HTML into React components via `dangerouslySetInnerHTML` in `src/app/docs/changelog/page.tsx` and `src/lib/docs.ts`, without any sanitization.
🎯 Impact: If the markdown source is compromised (e.g., if a GitHub release contains a malicious payload, or if docs are user-generated in the future), this would lead to a Cross-Site Scripting (XSS) vulnerability.
🔧 Fix: Wrapped the output of `marked()` with `DOMPurify.sanitize()` using `isomorphic-dompurify` for SSR compatibility.
✅ Verification: Ran `pnpm lint`, `pnpm test`, and `pnpm run build` to verify no regressions.

Also added a journal entry to `.jules/sentinel.md` documenting this finding.

---
*PR created automatically by Jules for task [15503852132644092420](https://jules.google.com/task/15503852132644092420) started by @aicoder2009*