### PR TITLE
🎨 Palette: Improve accessibility of WikiCollapsible component

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-12 - Added ARIA Attributes to Collapsible Component
+**Learning:** For accessible React interactive widgets like collapsibles, using React's `useId` hook is crucial to generate unique IDs for `aria-controls` mappings without collisions. Furthermore, providing a contextual `aria-label` (e.g., "Hide [Title]" or "Show [Title]") is essential for generic text buttons (like "[hide]" or "[show]") so that screen reader users have proper context, and reflecting the current state with `aria-expanded` completes the interaction pattern.
+**Action:** When creating or modifying generic toggle elements, always ensure `aria-expanded`, `aria-controls` (with a uniquely generated ID via `useId`), and a descriptive `aria-label` are present for complete screen reader accessibility.

--- a/src/components/wiki/wiki-collapsible.tsx
+++ b/src/components/wiki/wiki-collapsible.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useId } from "react";
 
 interface WikiCollapsibleProps {
   title: string;
@@ -14,6 +14,7 @@ export function WikiCollapsible({
   defaultOpen = true,
 }: WikiCollapsibleProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const contentId = useId();
 
   return (
     <div className="border border-wiki-border-light bg-wiki-offwhite">
@@ -21,12 +22,19 @@ export function WikiCollapsible({
         <span className="font-medium text-sm">{title}</span>
         <button
           onClick={() => setIsOpen(!isOpen)}
+          aria-expanded={isOpen}
+          aria-controls={isOpen ? contentId : undefined}
+          aria-label={`${isOpen ? "Hide" : "Show"} ${title}`}
           className="text-wiki-link text-sm hover:underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
         >
           [{isOpen ? "hide" : "show"}]
         </button>
       </div>
-      {isOpen && <div className="px-4 py-3">{children}</div>}
+      {isOpen && (
+        <div id={contentId} className="px-4 py-3">
+          {children}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
💡 What: Added ARIA attributes (`aria-expanded`, `aria-controls`, and `aria-label`) to the toggle button inside `WikiCollapsible`, and generated a unique ID using `useId`.

🎯 Why: The previous button only had a text child like "[show]" or "[hide]" with no context, causing issues for screen readers. Using `aria-expanded` and pointing to the dynamically mounted content via `aria-controls` creates a robust, accessible interaction pattern. Conditionally setting `aria-controls` when the element is unmounted prevents dangling ID references.

📸 Before/After: Visuals remain unchanged (verified via playwright screenshot).

♿ Accessibility:
- Screen readers now announce the button as "Show [Title]" or "Hide [Title]" instead of just "show/hide".
- Screen readers correctly announce the expansion state via `aria-expanded`.
- Screen readers correctly map the button to the content container via `aria-controls`.

---
*PR created automatically by Jules for task [13232428297091456706](https://jules.google.com/task/13232428297091456706) started by @aicoder2009*