### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS Vulnerability in Markdown Rendering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The application was passing unvalidated HTML variables, specifically `citation.formattedHtml`, to React's `dangerouslySetInnerHTML` prop in multiple components (`src/components/wiki/sortable-citation.tsx`, `src/app/cite/page.tsx`, `src/app/share/[code]/page.tsx`).
 **Learning:** This is a classic pattern for Cross-Site Scripting (XSS). If a citation's contents originated from an untrusted source or were maliciously formatted, an attacker could execute arbitrary scripts in a user's session when the citation is rendered.
 **Prevention:** Always sanitize any untrusted or dynamic HTML before rendering it in React. In a Next.js (SSR) application, use a library like `isomorphic-dompurify` to safely strip malicious scripts from the HTML payload on both the client and server side without hydration errors.
+
+## 2024-05-28 - [XSS] Missing HTML Sanitization in Docs & Changelog Rendering
+**Vulnerability:** The application was passing the output of `marked()` (which parses Markdown to HTML but does not sanitize it) directly into React's `dangerouslySetInnerHTML` in the changelog page (`src/app/docs/changelog/page.tsx`) and general docs (`src/lib/docs.ts`), introducing a Cross-Site Scripting (XSS) vulnerability if malicious Markdown was ever loaded (e.g. from GitHub release notes).
+**Learning:** The `marked` library does not sanitize HTML by default. When rendering Markdown content fetched from external sources (like GitHub APIs) or local files into React, it must be sanitized, as it is a textbook XSS vector.
+**Prevention:** Always wrap the output of `marked()` with `DOMPurify.sanitize()` (using `isomorphic-dompurify` in Next.js) before passing it to `dangerouslySetInnerHTML`.

--- a/src/app/docs/changelog/page.tsx
+++ b/src/app/docs/changelog/page.tsx
@@ -1,6 +1,7 @@
 import { WikiBreadcrumbs } from "@/components/wiki/wiki-breadcrumbs";
 import { getGitHubReleases, getGitHubCommits } from "@/lib/github";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export const metadata = { title: "Changelog — OpenCitation" };
 
@@ -91,7 +92,7 @@ export default async function ChangelogPage() {
               {release.body ? (
                 <div
                   className="docs-content px-4 py-4"
-                  dangerouslySetInnerHTML={{ __html: marked(release.body) as string }}
+                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked(release.body) as string) }}
                 />
               ) : (
                 <p className="px-4 py-4 text-sm text-wiki-text-muted italic">No release notes.</p>

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export async function getDocContent(slug: string): Promise<string> {
   const filePath = join(process.cwd(), "docs/content", `${slug}.md`);
   const markdown = readFileSync(filePath, "utf-8");
-  return await marked(markdown);
+  const html = await marked(markdown);
+  return DOMPurify.sanitize(html);
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application was passing the output of `marked()` directly into React's `dangerouslySetInnerHTML` in the changelog page (`src/app/docs/changelog/page.tsx`) and general docs (`src/lib/docs.ts`), which introduces a Cross-Site Scripting (XSS) vulnerability if malicious Markdown was ever loaded (e.g., from GitHub release notes). The `marked` library does not sanitize HTML by default.
🎯 **Impact:** If malicious Markdown with embedded scripts was rendered through the `dangerouslySetInnerHTML` without being sanitized, it would lead to XSS execution on the user's browser, allowing an attacker to execute arbitrary scripts in a user's session.
🔧 **Fix:** Imported `DOMPurify` from `isomorphic-dompurify` and wrapped the output of the `marked()` function with `DOMPurify.sanitize()` before passing it into `dangerouslySetInnerHTML` to strip any malicious scripts or tags.
✅ **Verification:** Verified by checking `pnpm lint` and `pnpm test` to ensure there are no regressions or execution errors.

---
*PR created automatically by Jules for task [6797412267854174701](https://jules.google.com/task/6797412267854174701) started by @aicoder2009*