### PR TITLE
🎨 Palette: Add contextual ARIA labels to generic action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-19 - Contextual ARIA Labels for Repeated Generic Actions
+**Learning:** Generic visual action texts like `[edit]`, `[view]`, `[delete]`, `[remove]`, and `[save]` used repeatedly inside tables or mapped lists lack context for screen reader users when navigated out-of-context (e.g., via a screen reader's elements list).
+**Action:** Always provide a contextual `aria-label` (e.g., `aria-label={\`Edit project \${project.name}\`}`) for buttons with generic visual text to ensure screen reader users have proper context.

--- a/src/app/lists/[id]/page.tsx
+++ b/src/app/lists/[id]/page.tsx
@@ -1187,6 +1187,7 @@ export default function ListDetailPage({
                     <button
                       onClick={() => setIsEditing(true)}
                       className="ml-2 text-wiki-link text-sm font-normal hover:underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
+                      aria-label={`Edit list ${list?.name}`}
                     >
                       [edit]
                     </button>

--- a/src/app/lists/page.tsx
+++ b/src/app/lists/page.tsx
@@ -320,12 +320,14 @@ export default function ListsPage() {
                         <button
                           onClick={() => router.push(`/lists/${list.id}`)}
                           className="text-wiki-link hover:underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
+                          aria-label={`View list ${list.name}`}
                         >
                           [view]
                         </button>
                         <button
                           onClick={() => handleDeleteList(list.id, list.name)}
                           className="text-wiki-link hover:underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
+                          aria-label={`Delete list ${list.name}`}
                         >
                           [delete]
                         </button>

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -322,6 +322,7 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                     <button
                       onClick={() => setIsEditing(true)}
                       className="ml-2 text-wiki-link text-sm font-normal hover:underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
+                      aria-label={`Edit project ${project?.name}`}
                     >
                       [edit]
                     </button>
@@ -462,12 +463,14 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
                         <button
                           onClick={() => router.push(`/lists/${list.id}`)}
                           className="text-wiki-link hover:underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
+                          aria-label={`View list ${list.name}`}
                         >
                           [view]
                         </button>
                         <button
                           onClick={() => handleRemoveFromProject(list.id)}
                           className="text-wiki-link hover:underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
+                          aria-label={`Remove list ${list.name} from project`}
                         >
                           [remove]
                         </button>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -374,6 +374,7 @@ export default function ProjectsPage() {
                             onClick={() => handleSaveEdit(project.id)}
                             disabled={isSavingEdit || !editName.trim()}
                             className="text-wiki-link hover:underline disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
+                            aria-label={`Save edits to project ${project.name}`}
                           >
                             {isSavingEdit ? "[saving...]" : "[save]"}
                           </button>
@@ -381,6 +382,7 @@ export default function ProjectsPage() {
                             onClick={cancelEditing}
                             disabled={isSavingEdit}
                             className="text-wiki-text-muted hover:underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
+                            aria-label="Cancel editing"
                           >
                             [cancel]
                           </button>
@@ -390,18 +392,21 @@ export default function ProjectsPage() {
                           <button
                             onClick={() => router.push(`/projects/${project.id}`)}
                             className="text-wiki-link hover:underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
+                            aria-label={`View project ${project.name}`}
                           >
                             [view]
                           </button>
                           <button
                             onClick={() => startEditing(project)}
                             className="text-wiki-link hover:underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
+                            aria-label={`Edit project ${project.name}`}
                           >
                             [edit]
                           </button>
                           <button
                             onClick={() => handleDeleteProject(project.id, project.name)}
                             className="text-wiki-link hover:underline ml-auto focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
+                            aria-label={`Delete project ${project.name}`}
                           >
                             [delete]
                           </button>


### PR DESCRIPTION
Adds contextual `aria-label` attributes to the generic action buttons like `[view]`, `[edit]`, `[delete]`, `[remove]`, `[save]`, and `[cancel]` inside the mapped lists and tables in `src/app/projects/page.tsx`, `src/app/lists/page.tsx`, `src/app/projects/[id]/page.tsx`, and `src/app/lists/[id]/page.tsx`. This change improves screen reader context when navigating these interactive elements out-of-context. Also adds a corresponding journal entry to `.jules/palette.md`.

---
*PR created automatically by Jules for task [2757776804981441192](https://jules.google.com/task/2757776804981441192) started by @aicoder2009*