### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in Markdown parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The application was passing unvalidated HTML variables, specifically `citation.formattedHtml`, to React's `dangerouslySetInnerHTML` prop in multiple components (`src/components/wiki/sortable-citation.tsx`, `src/app/cite/page.tsx`, `src/app/share/[code]/page.tsx`).
 **Learning:** This is a classic pattern for Cross-Site Scripting (XSS). If a citation's contents originated from an untrusted source or were maliciously formatted, an attacker could execute arbitrary scripts in a user's session when the citation is rendered.
 **Prevention:** Always sanitize any untrusted or dynamic HTML before rendering it in React. In a Next.js (SSR) application, use a library like `isomorphic-dompurify` to safely strip malicious scripts from the HTML payload on both the client and server side without hydration errors.
+
+## 2025-02-28 - Enforce XSS Sanitization on all Markdown Renders
+**Vulnerability:** The application was using the `marked` library to parse Markdown content into HTML and rendering it via React's `dangerouslySetInnerHTML` without proper sanitization. Specifically, in `src/app/docs/changelog/page.tsx` (parsing untrusted external data from GitHub releases) and `src/lib/docs.ts` (parsing static markdown files).
+**Learning:** `marked` does not sanitize HTML by default. When wrapping its output in `dangerouslySetInnerHTML`, it directly exposes the application to Cross-Site Scripting (XSS) vulnerabilities if the input is untrusted or tampered with.
+**Prevention:** Always wrap the output of `marked()` with `DOMPurify.sanitize()` (via `isomorphic-dompurify` for SSR/Server Components) before passing it to `dangerouslySetInnerHTML`.

--- a/src/app/docs/changelog/page.tsx
+++ b/src/app/docs/changelog/page.tsx
@@ -1,6 +1,7 @@
 import { WikiBreadcrumbs } from "@/components/wiki/wiki-breadcrumbs";
 import { getGitHubReleases, getGitHubCommits } from "@/lib/github";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export const metadata = { title: "Changelog — OpenCitation" };
 
@@ -91,7 +92,8 @@ export default async function ChangelogPage() {
               {release.body ? (
                 <div
                   className="docs-content px-4 py-4"
-                  dangerouslySetInnerHTML={{ __html: marked(release.body) as string }}
+                  // XSS Prevention: marked output is untrusted (from external API)
+                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked(release.body) as string) }}
                 />
               ) : (
                 <p className="px-4 py-4 text-sm text-wiki-text-muted italic">No release notes.</p>

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,9 +1,12 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export async function getDocContent(slug: string): Promise<string> {
   const filePath = join(process.cwd(), "docs/content", `${slug}.md`);
   const markdown = readFileSync(filePath, "utf-8");
-  return await marked(markdown);
+  const html = await marked(markdown);
+  // XSS Prevention: ensure all markdown parsing is uniformly sanitized
+  return DOMPurify.sanitize(html);
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The application was passing the output of `marked()` directly to React's `dangerouslySetInnerHTML`. Because `marked` does not sanitize HTML by default, any malicious tags in the markdown input (e.g., in GitHub release notes or potentially compromised static docs) would be executed in the user's browser, leading to XSS.
🎯 Impact: Attackers could execute arbitrary JavaScript within a user's session if they control the parsed markdown content.
🔧 Fix: Wrapped all `marked()` outputs with `DOMPurify.sanitize()` (using `isomorphic-dompurify`) before rendering them.
✅ Verification: Ran `pnpm lint` and `pnpm test` successfully. Verified XSS mitigation manually with a scratchpad script. Recorded learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [7006840903964969019](https://jules.google.com/task/7006840903964969019) started by @aicoder2009*