### PR TITLE
🎨 Palette: Improve accessibility of WikiCollapsible component

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Accessible Collapsible Content
+**Learning:** When conditionally mounting/unmounting React elements controlled by an ARIA button (e.g., collapsible content), it is important to conditionally set the button's `aria-controls` to `undefined` when the target is unmounted. Additionally, generic visual text like "[hide]" or "[show]" lacks context for screen readers; they should use context-aware `aria-label`s like "Show [Title]".
+**Action:** Use React's `useId` to reliably link `aria-controls` to DOM IDs without collision risk, conditionally clear `aria-controls` when the child component unmounts, and add descriptive `aria-label`s replacing generic toggle text.

--- a/src/components/wiki/wiki-collapsible.tsx
+++ b/src/components/wiki/wiki-collapsible.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useId } from "react";
 
 interface WikiCollapsibleProps {
   title: string;
@@ -14,6 +14,7 @@ export function WikiCollapsible({
   defaultOpen = true,
 }: WikiCollapsibleProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const contentId = useId();
 
   return (
     <div className="border border-wiki-border-light bg-wiki-offwhite">
@@ -21,12 +22,15 @@ export function WikiCollapsible({
         <span className="font-medium text-sm">{title}</span>
         <button
           onClick={() => setIsOpen(!isOpen)}
+          aria-expanded={isOpen}
+          aria-controls={isOpen ? contentId : undefined}
+          aria-label={isOpen ? `Hide ${title}` : `Show ${title}`}
           className="text-wiki-link text-sm hover:underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
         >
           [{isOpen ? "hide" : "show"}]
         </button>
       </div>
-      {isOpen && <div className="px-4 py-3">{children}</div>}
+      {isOpen && <div id={contentId} className="px-4 py-3">{children}</div>}
     </div>
   );
 }


### PR DESCRIPTION
💡 What: Added essential ARIA attributes (`aria-expanded`, `aria-controls`, and `aria-label`) and a dynamic DOM ID (`useId()`) to the `WikiCollapsible` component.
🎯 Why: The previous implementation relied on generic `[hide]` or `[show]` text for its toggle button without programmatically linking the button to its controlled content or conveying the open/closed state. This improves the screen reader experience, ensuring users have context-aware interactions (e.g. "Show Contents" instead of just "show").
♿ Accessibility:
- Focus and context are dramatically improved by using explicit `aria-label`s instead of screen readers just reading out the generic visual tag.
- Keyboard and screen reader users can now determine whether the controlled region is open using `aria-expanded`.
- The toggle button controls the content dynamically via `aria-controls`, and the controls property is safely removed when the target content is unmounted.

---
*PR created automatically by Jules for task [3236787985788402156](https://jules.google.com/task/3236787985788402156) started by @aicoder2009*