### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XSS vulnerability in Markdown rendering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The application was passing unvalidated HTML variables, specifically `citation.formattedHtml`, to React's `dangerouslySetInnerHTML` prop in multiple components (`src/components/wiki/sortable-citation.tsx`, `src/app/cite/page.tsx`, `src/app/share/[code]/page.tsx`).
 **Learning:** This is a classic pattern for Cross-Site Scripting (XSS). If a citation's contents originated from an untrusted source or were maliciously formatted, an attacker could execute arbitrary scripts in a user's session when the citation is rendered.
 **Prevention:** Always sanitize any untrusted or dynamic HTML before rendering it in React. In a Next.js (SSR) application, use a library like `isomorphic-dompurify` to safely strip malicious scripts from the HTML payload on both the client and server side without hydration errors.
+
+## 2025-05-01 - Missing Sanitization in Markdown Rendering
+**Vulnerability:** Found multiple instances where the output of the `marked` library was directly passed to React's `dangerouslySetInnerHTML` without any HTML sanitization, introducing a critical Cross-Site Scripting (XSS) risk.
+**Learning:** By default, the `marked` library only parses Markdown into HTML; it does not sanitize the output. Directly rendering its output exposes the application to XSS attacks if the source Markdown contains malicious embedded HTML or `<script>` tags.
+**Prevention:** All parsed HTML output from Markdown libraries (like `marked`) must be strictly sanitized using a library like `isomorphic-dompurify` (calling `DOMPurify.sanitize()`) prior to being rendered in the DOM, especially when using potentially dangerous hooks like `dangerouslySetInnerHTML`.

--- a/src/app/docs/changelog/page.tsx
+++ b/src/app/docs/changelog/page.tsx
@@ -1,6 +1,7 @@
 import { WikiBreadcrumbs } from "@/components/wiki/wiki-breadcrumbs";
 import { getGitHubReleases, getGitHubCommits } from "@/lib/github";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export const metadata = { title: "Changelog — OpenCitation" };
 
@@ -91,7 +92,7 @@ export default async function ChangelogPage() {
               {release.body ? (
                 <div
                   className="docs-content px-4 py-4"
-                  dangerouslySetInnerHTML={{ __html: marked(release.body) as string }}
+                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked(release.body) as string) }}
                 />
               ) : (
                 <p className="px-4 py-4 text-sm text-wiki-text-muted italic">No release notes.</p>

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export async function getDocContent(slug: string): Promise<string> {
   const filePath = join(process.cwd(), "docs/content", `${slug}.md`);
   const markdown = readFileSync(filePath, "utf-8");
-  return await marked(markdown);
+  const html = await marked(markdown);
+  return DOMPurify.sanitize(html);
 }


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix XSS vulnerability in Markdown rendering

🚨 Severity: CRITICAL
💡 Vulnerability: The application used the `marked` library to parse Markdown and passed the output directly to React's `dangerouslySetInnerHTML`. Because `marked` does not sanitize HTML by default, any malicious HTML or script tags embedded in the Markdown content would be executed in the user's browser, leading to Cross-Site Scripting (XSS).
🎯 Impact: An attacker could embed malicious scripts in GitHub release notes or potentially local documentation, which would then execute in the context of the application when a user viewed the changelog or documentation pages.
🔧 Fix: Imported `DOMPurify` from `isomorphic-dompurify` and wrapped the output of `marked()` with `DOMPurify.sanitize()` before passing it to `dangerouslySetInnerHTML`. This ensures any malicious HTML is safely stripped out.
✅ Verification: Ensure the `pnpm lint` and `pnpm test` commands pass and review the diff to see the sanitization wrapper around `marked()` calls.

---
*PR created automatically by Jules for task [8898566306029201819](https://jules.google.com/task/8898566306029201819) started by @aicoder2009*