### PR TITLE
🎨 Palette: Improve WikiCollapsible ARIA accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessible Conditionally Mounted Collapsible Content
+**Learning:** When conditionally mounting React elements controlled by an ARIA button (e.g., collapsible content or dropdowns), screen readers may attempt to read from a missing DOM ID if the element is not present.
+**Action:** Conditionally set the button's `aria-controls` to `undefined` when the target content is unmounted (e.g., `aria-controls={isOpen ? contentId : undefined}`). Also, remember to generate the `contentId` with React's `useId()` hook to avoid ID collisions, and use `aria-expanded` and clear `aria-label`s on generic/icon toggle buttons.

--- a/src/components/wiki/wiki-collapsible.tsx
+++ b/src/components/wiki/wiki-collapsible.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useId } from "react";
 
 interface WikiCollapsibleProps {
   title: string;
@@ -14,6 +14,7 @@ export function WikiCollapsible({
   defaultOpen = true,
 }: WikiCollapsibleProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const contentId = useId();
 
   return (
     <div className="border border-wiki-border-light bg-wiki-offwhite">
@@ -21,12 +22,15 @@ export function WikiCollapsible({
         <span className="font-medium text-sm">{title}</span>
         <button
           onClick={() => setIsOpen(!isOpen)}
+          aria-expanded={isOpen}
+          aria-controls={isOpen ? contentId : undefined}
+          aria-label={`${isOpen ? "Hide" : "Show"} ${title}`}
           className="text-wiki-link text-sm hover:underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
         >
           [{isOpen ? "hide" : "show"}]
         </button>
       </div>
-      {isOpen && <div className="px-4 py-3">{children}</div>}
+      {isOpen && <div id={contentId} className="px-4 py-3">{children}</div>}
     </div>
   );
 }


### PR DESCRIPTION
**What:** Added `aria-expanded`, `aria-label`, and a conditionally mapped `aria-controls` attribute using `useId()` to the `WikiCollapsible` toggle button.
**Why:** To ensure screen readers properly convey the collapsible state to users without reporting missing IDs when unmounted.
**Accessibility:** Improves screen reader announcements and element relationships.

---
*PR created automatically by Jules for task [7149763391616095602](https://jules.google.com/task/7149763391616095602) started by @aicoder2009*