### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS from unsanitized marked output

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The application was passing unvalidated HTML variables, specifically `citation.formattedHtml`, to React's `dangerouslySetInnerHTML` prop in multiple components (`src/components/wiki/sortable-citation.tsx`, `src/app/cite/page.tsx`, `src/app/share/[code]/page.tsx`).
 **Learning:** This is a classic pattern for Cross-Site Scripting (XSS). If a citation's contents originated from an untrusted source or were maliciously formatted, an attacker could execute arbitrary scripts in a user's session when the citation is rendered.
 **Prevention:** Always sanitize any untrusted or dynamic HTML before rendering it in React. In a Next.js (SSR) application, use a library like `isomorphic-dompurify` to safely strip malicious scripts from the HTML payload on both the client and server side without hydration errors.
+## 2025-02-28 - [XSS via unsanitized marked output]
+**Vulnerability:** The application was using the `marked` library to parse Markdown content into HTML (in `src/app/docs/changelog/page.tsx` and `src/lib/docs.ts`) and subsequently rendering it using `dangerouslySetInnerHTML` without proper sanitization.
+**Learning:** `marked` does not sanitize HTML by default. While this may seem safe for trusted inputs (like internal docs or GitHub releases), if malicious input manages to enter these sources, it leads directly to an XSS vulnerability.
+**Prevention:** The output of `marked` (or any markdown parser) must always be wrapped with `DOMPurify.sanitize()` (using `isomorphic-dompurify` for SSR) before being passed to `dangerouslySetInnerHTML`.

--- a/src/app/docs/changelog/page.tsx
+++ b/src/app/docs/changelog/page.tsx
@@ -1,6 +1,7 @@
 import { WikiBreadcrumbs } from "@/components/wiki/wiki-breadcrumbs";
 import { getGitHubReleases, getGitHubCommits } from "@/lib/github";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export const metadata = { title: "Changelog — OpenCitation" };
 
@@ -91,7 +92,7 @@ export default async function ChangelogPage() {
               {release.body ? (
                 <div
                   className="docs-content px-4 py-4"
-                  dangerouslySetInnerHTML={{ __html: marked(release.body) as string }}
+                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked(release.body) as string) }}
                 />
               ) : (
                 <p className="px-4 py-4 text-sm text-wiki-text-muted italic">No release notes.</p>

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,9 +1,10 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
 
 export async function getDocContent(slug: string): Promise<string> {
   const filePath = join(process.cwd(), "docs/content", `${slug}.md`);
   const markdown = readFileSync(filePath, "utf-8");
-  return await marked(markdown);
+  return DOMPurify.sanitize(await marked(markdown));
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `marked` library was used to parse Markdown content and the output was being fed directly into React's `dangerouslySetInnerHTML` without proper sanitization. By default, `marked` does not sanitize HTML, making it a prime vector for Cross-Site Scripting (XSS).
🎯 Impact: If malicious code finds its way into Markdown inputs (like dynamically fetched documentation or GitHub release bodies), an attacker could execute arbitrary JavaScript within a user's session when the page is rendered.
🔧 Fix: Wrapped the output of `marked()` with `DOMPurify.sanitize()` (from the already present `isomorphic-dompurify` package) before rendering it using `dangerouslySetInnerHTML` in both `src/app/docs/changelog/page.tsx` and `src/lib/docs.ts`.
✅ Verification: Ran `pnpm test` and `pnpm lint` and manually verified the code correctly uses the sanitizer. Review evaluated the implementation as #Correct#.

---
*PR created automatically by Jules for task [2969530552408105064](https://jules.google.com/task/2969530552408105064) started by @aicoder2009*