### PR TITLE
⚡ Bolt: Concurrent data fetching in GET /api/share

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Optimize share links endpoint
+**Learning:** Sequential database queries for independent data models (shares, user lists, user projects) inside API routes cause unnecessary waterfall execution latency, leading to increased Time to First Byte (TTFB). Next.js API routes with multiple asynchronous requests to DB can significantly benefit from parallel execution.
+**Action:** Use `Promise.all()` to execute network and database requests concurrently when fetching independent data models to optimize response times.

--- a/src/app/api/share/route.ts
+++ b/src/app/api/share/route.ts
@@ -22,11 +22,14 @@ export async function GET() {
       );
     }
 
-    const shares = await listUserShares(userId);
+    // Fetch shares, lists, and projects concurrently to eliminate waterfall latency
+    const [shares, lists, projects] = await Promise.all([
+      listUserShares(userId),
+      getUserLists(userId),
+      getUserProjects(userId),
+    ]);
 
     // Enrich with target name so the UI can render without extra round-trips.
-    const lists = await getUserLists(userId);
-    const projects = await getUserProjects(userId);
     const listById = new Map(lists.map((l) => [l.id, l]));
     const projectById = new Map(projects.map((p) => [p.id, p]));
 


### PR DESCRIPTION
💡 **What:** The `GET /api/share` endpoint was refactored to fetch user shares, lists, and projects concurrently using `Promise.all()`.

🎯 **Why:** Previously, the endpoint executed these three independent database queries sequentially (`listUserShares`, `getUserLists`, `getUserProjects`). Since none of these queries depend on the results of the others (they all only require `userId`), the sequential `await` calls created unnecessary waterfall execution, leading to increased Time to First Byte (TTFB). 

📊 **Impact:** This optimization reduces the overall database latency for the endpoint. The total time spent fetching this initial data is now bound by the single slowest query, rather than the sum of all three query times, noticeably speeding up the initial load of the user's share management view. 

🔬 **Measurement:** The performance improvement can be verified using browser dev tools (Network tab) or via API load testing tools (like `k6` or `autocannon`) by comparing the response time of `GET /api/share` before and after this change. Local `pnpm test:run` results confirm that the behavioral contract of the endpoint remains completely unchanged.

---
*PR created automatically by Jules for task [14875981879349558133](https://jules.google.com/task/14875981879349558133) started by @aicoder2009*