### PR TITLE
🎨 Palette: Improve accessibility of WikiCollapsible toggle button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-16 - Contextual ARIA attributes for Generic Toggle Buttons
+**Learning:** Generic visual toggle buttons like `[hide]` / `[show]` present accessibility challenges because their visual text alone doesn't describe the target. Simply changing the text is insufficient. Furthermore, screen readers can stumble if `aria-controls` points to an unmounted DOM ID when content is hidden.
+**Action:** Always provide context by combining dynamic generic text with a descriptive `aria-label` (e.g., `"Hide [Title]"`). Ensure `aria-expanded` reflects state, and conditionally remove `aria-controls` (set to `undefined`) when the target element is unmounted from the DOM to avoid ID reference errors.

--- a/src/components/wiki/wiki-collapsible.tsx
+++ b/src/components/wiki/wiki-collapsible.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useId } from "react";
 
 interface WikiCollapsibleProps {
   title: string;
@@ -14,6 +14,7 @@ export function WikiCollapsible({
   defaultOpen = true,
 }: WikiCollapsibleProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const contentId = useId();
 
   return (
     <div className="border border-wiki-border-light bg-wiki-offwhite">
@@ -22,11 +23,14 @@ export function WikiCollapsible({
         <button
           onClick={() => setIsOpen(!isOpen)}
           className="text-wiki-link text-sm hover:underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
+          aria-expanded={isOpen}
+          aria-controls={isOpen ? contentId : undefined}
+          aria-label={`${isOpen ? "Hide" : "Show"} ${title}`}
         >
           [{isOpen ? "hide" : "show"}]
         </button>
       </div>
-      {isOpen && <div className="px-4 py-3">{children}</div>}
+      {isOpen && <div id={contentId} className="px-4 py-3">{children}</div>}
     </div>
   );
 }


### PR DESCRIPTION
💡 What: Added `useId` and comprehensive ARIA attributes (`aria-expanded`, conditional `aria-controls`, and contextual `aria-label`) to the generic `[hide]`/`[show]` toggle button in `src/components/wiki/wiki-collapsible.tsx`.

🎯 Why: Generic visual text like `[hide]` or `[show]` fails to provide adequate context for screen readers. Further, pointing `aria-controls` to an unmounted DOM ID when content is collapsed creates ID reference errors in accessibility tools.

♿ Accessibility:
- Screen readers now announce the specific section being toggled (e.g., "Hide List Name, button, expanded").
- Prevented potential ID collision issues with React's `useId`.
- Safely avoided ID reference errors by passing `undefined` to `aria-controls` when the content div is not rendered in the DOM.

---
*PR created automatically by Jules for task [12155894494719712858](https://jules.google.com/task/12155894494719712858) started by @aicoder2009*