### PR TITLE
🎨 Palette: Enhance accessibility of generic visual text buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,7 @@
+## 2024-05-17 - React Conditional Unmounting and aria-controls
+**Learning:** When React conditionally unmounts an element controlled by an ARIA button (like a collapsible panel), leaving `aria-controls` pointing to the now-missing DOM ID causes screen readers to announce broken references.
+**Action:** Always set `aria-controls={isOpen ? panelId : undefined}` when the target element is completely removed from the DOM, rather than just visually hidden.
+
+## 2024-05-17 - Generic Visual Text Buttons and ARIA Context
+**Learning:** Components frequently use generic visual text buttons like `[hide]`, `[show]`, `[edit]`, or `[delete]` within lists or loops. Screen readers read these buttons without surrounding visual context, confusing users.
+**Action:** Always provide a contextual `aria-label` (e.g., `aria-label="Hide ${title}"`) for generic visual text buttons so screen reader users have proper context.

--- a/src/components/wiki/wiki-collapsible.tsx
+++ b/src/components/wiki/wiki-collapsible.tsx
@@ -23,7 +23,8 @@ export function WikiCollapsible({
         <button
           onClick={() => setIsOpen(!isOpen)}
           aria-expanded={isOpen}
-          aria-controls={panelId}
+          aria-controls={isOpen ? panelId : undefined}
+          aria-label={`${isOpen ? "Hide" : "Show"} ${title}`}
           className="text-wiki-link text-sm hover:underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
         >
           [{isOpen ? "hide" : "show"}]


### PR DESCRIPTION
This PR addresses an accessibility issue in the `WikiCollapsible` component where the toggle button uses generic text (`[hide]`/`[show]`) without providing context to screen readers. 

Changes include:
* Added a dynamic `aria-label` to the toggle button (e.g., "Hide [Title]") to clarify its function.
* Conditionally rendered the `aria-controls` attribute (`aria-controls={isOpen ? panelId : undefined}`) to prevent screen readers from referencing a missing DOM element when the panel is collapsed/unmounted.
* Added findings to `.jules/palette.md` to document this learning for future reference.

---
*PR created automatically by Jules for task [13036944877194248814](https://jules.google.com/task/13036944877194248814) started by @aicoder2009*