### PR TITLE
🎨 Palette: Add aria-controls and aria-expanded to navigation menus

### DIFF
--- a/src/components/wiki/wiki-layout.tsx
+++ b/src/components/wiki/wiki-layout.tsx
@@ -148,6 +148,7 @@ export function WikiLayout({ children, hideFooter = false }: WikiLayoutProps) {
                   onKeyDown={handleDocsKeyDown}
                   aria-haspopup="menu"
                   aria-expanded={docsOpen}
+                  aria-controls={docsOpen ? "docs-menu-signed-out" : undefined}
                   className="flex items-center gap-0.5 text-wiki-link hover:underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
                 >
                   Docs
@@ -156,7 +157,7 @@ export function WikiLayout({ children, hideFooter = false }: WikiLayoutProps) {
                   </svg>
                 </button>
                 {docsOpen && (
-                  <div className="absolute right-0 top-full mt-1 z-20 min-w-[160px] bg-wiki-white border border-wiki-border-light shadow-md">
+                  <div id="docs-menu-signed-out" className="absolute right-0 top-full mt-1 z-20 min-w-[160px] bg-wiki-white border border-wiki-border-light shadow-md">
                     <Link href="/docs" className="block px-4 py-2 text-sm text-wiki-link hover:bg-wiki-tab-bg hover:no-underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text">
                       Documentation
                     </Link>
@@ -195,6 +196,7 @@ export function WikiLayout({ children, hideFooter = false }: WikiLayoutProps) {
                   onKeyDown={handleDocsKeyDown}
                   aria-haspopup="menu"
                   aria-expanded={docsOpen}
+                  aria-controls={docsOpen ? "docs-menu-signed-in" : undefined}
                   className="flex items-center gap-0.5 text-wiki-link hover:underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
                 >
                   Docs
@@ -203,7 +205,7 @@ export function WikiLayout({ children, hideFooter = false }: WikiLayoutProps) {
                   </svg>
                 </button>
                 {docsOpen && (
-                  <div className="absolute right-0 top-full mt-1 z-20 min-w-[160px] bg-wiki-white border border-wiki-border-light shadow-md">
+                  <div id="docs-menu-signed-in" className="absolute right-0 top-full mt-1 z-20 min-w-[160px] bg-wiki-white border border-wiki-border-light shadow-md">
                     <Link href="/docs" className="block px-4 py-2 text-sm text-wiki-link hover:bg-wiki-tab-bg hover:no-underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text">
                       Documentation
                     </Link>
@@ -229,6 +231,8 @@ export function WikiLayout({ children, hideFooter = false }: WikiLayoutProps) {
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
               className="p-1 text-wiki-text focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
               aria-label="Toggle menu"
+              aria-expanded={mobileMenuOpen}
+              aria-controls={mobileMenuOpen ? "mobile-menu" : undefined}
             >
               <svg
                 aria-hidden="true"
@@ -259,7 +263,7 @@ export function WikiLayout({ children, hideFooter = false }: WikiLayoutProps) {
 
         {/* Mobile Menu */}
         {mobileMenuOpen && (
-          <div className="sm:hidden border-t border-wiki-border-light bg-wiki-offwhite">
+          <div id="mobile-menu" className="sm:hidden border-t border-wiki-border-light bg-wiki-offwhite">
             <nav className="max-w-[960px] mx-auto px-4 py-3 flex flex-col gap-2 text-sm">
               <Link
                 href="/cite"


### PR DESCRIPTION
## 💡 What: The UX enhancement added
Added standard `aria-controls` accessibility attributes to link the `<button>` toggles to the content `<div>`s they control in `wiki-layout.tsx` (the "Docs" dropdowns and the Mobile Menu toggle). I also ensured they had explicit IDs. Crucially, the `aria-controls` attribute is conditionally rendered to `undefined` when the target is unmounted to prevent screen readers from navigating to "broken" or missing references. I also added missing `aria-expanded` to the mobile menu.

## 🎯 Why: The user problem it solves
Screen reader users interacting with the Docs dropdown or the mobile menu button would be told that the button controls a menu (via `aria-haspopup="menu"`), but they wouldn't have a semantic programmatic link to the content that appears. Also, if a menu is unmounted from the DOM rather than visually hidden, leaving a stale `aria-controls` creates errors in assistive technology.

## ♿ Accessibility: Any a11y improvements made
*   Added `aria-expanded` to mobile menu toggle.
*   Added conditionally rendered `aria-controls` mappings to the Desktop "Docs" menus (both SignedOut and SignedIn variations) and the Mobile Menu.
*   Applied ID attributes to the target dropdown/menu elements.

---
*PR created automatically by Jules for task [11902536083893132803](https://jules.google.com/task/11902536083893132803) started by @aicoder2009*