### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF via Host Header Injection in bulk lookup API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** The application was using the `marked` library to parse Markdown content into HTML (in `src/app/docs/changelog/page.tsx` and `src/lib/docs.ts`) and subsequently rendering it using `dangerouslySetInnerHTML` without proper sanitization.
 **Learning:** `marked` does not sanitize HTML by default. While this may seem safe for trusted inputs (like internal docs or GitHub releases), if malicious input manages to enter these sources, it leads directly to an XSS vulnerability.
 **Prevention:** The output of `marked` (or any markdown parser) must always be wrapped with `DOMPurify.sanitize()` (using `isomorphic-dompurify` for SSR) before being passed to `dangerouslySetInnerHTML`.
+
+## 2025-02-27 - SSRF via Host Header Injection in Internal API Calls
+**Vulnerability:** The `/api/lookup/bulk` endpoint used `request.nextUrl.origin` to construct internal API URLs and execute them via `fetch()`. Since `request.nextUrl.origin` is derived from the HTTP `Host` header (which is attacker-controllable), an attacker could set `Host: malicious.com` and cause the bulk lookup to send its payload to an external server. Furthermore, because of X-Forwarded-Host injection, it could be used for SSRF to local IP ports (like `127.0.0.1:9090`).
+**Learning:** Never use `fetch()` combined with dynamically derived hostnames (e.g., from `request.nextUrl.origin` or `Host` headers) to invoke internal Next.js API endpoints. This creates an SSRF and potential data leakage vector.
+**Prevention:** Instead of performing an HTTP loopback via `fetch()`, invoke the route handler functions directly (e.g., `import { POST } from "../url/route"; POST(mockRequest);`) or refactor the shared logic into a standalone library module that both routes can call.

--- a/src/app/api/lookup/bulk/route.test.ts
+++ b/src/app/api/lookup/bulk/route.test.ts
@@ -1,8 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from './route';
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
-global.fetch = vi.fn();
+vi.mock('../url/route', () => ({
+  POST: vi.fn(async () => NextResponse.json({ data: { title: 'Example Page' } }, { status: 200 }))
+}));
+vi.mock('../doi/route', () => ({
+  POST: vi.fn(async () => NextResponse.json({ data: { title: 'Research Article' } }, { status: 200 }))
+}));
+vi.mock('../isbn/route', () => ({
+  POST: vi.fn(async () => NextResponse.json({ data: { title: 'Book Title' } }, { status: 200 }))
+}));
+
+import { POST as handleUrl } from '../url/route';
+import { POST as handleDoi } from '../doi/route';
+import { POST as handleIsbn } from '../isbn/route';
 
 function makeRequest(body: object) {
   return new NextRequest('http://localhost/api/lookup/bulk', {
@@ -54,47 +66,34 @@ describe('Bulk Lookup API', () => {
   });
 
   it('routes URLs to /api/lookup/url', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ data: { title: 'Example Page' } }),
-    });
+    vi.mocked(handleUrl).mockResolvedValueOnce(NextResponse.json({ data: { title: 'Example Page' } }, { status: 200 }));
     const response = await POST(makeRequest({ items: ['https://example.com'] }));
     const data = await response.json();
     expect(data.results[0].success).toBe(true);
     expect(data.results[0].data.title).toBe('Example Page');
-    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
-    expect(url).toContain('/api/lookup/url');
+    expect(handleUrl).toHaveBeenCalled();
   });
 
   it('routes DOIs to /api/lookup/doi', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ data: { title: 'Research Article' } }),
-    });
+    vi.mocked(handleDoi).mockResolvedValueOnce(NextResponse.json({ data: { title: 'Research Article' } }, { status: 200 }));
     const response = await POST(makeRequest({ items: ['10.1000/xyz123'] }));
     const data = await response.json();
     expect(data.results[0].success).toBe(true);
-    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
-    expect(url).toContain('/api/lookup/doi');
+    expect(handleDoi).toHaveBeenCalled();
   });
 
   it('routes ISBNs to /api/lookup/isbn', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ data: { title: 'Book Title' } }),
-    });
+    vi.mocked(handleIsbn).mockResolvedValueOnce(NextResponse.json({ data: { title: 'Book Title' } }, { status: 200 }));
     const response = await POST(makeRequest({ items: ['9780316769174'] }));
     const data = await response.json();
     expect(data.results[0].success).toBe(true);
-    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
-    expect(url).toContain('/api/lookup/isbn');
+    expect(handleIsbn).toHaveBeenCalled();
   });
 
   it('marks item as failed when sub-request fails', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ error: 'Not found' }),
-    });
+    vi.mocked(handleDoi).mockResolvedValueOnce(
+      NextResponse.json({ error: 'Not found' }, { status: 404 })
+    );
     const response = await POST(makeRequest({ items: ['10.1000/nonexistent'] }));
     const data = await response.json();
     expect(data.results[0].success).toBe(false);
@@ -102,9 +101,8 @@ describe('Bulk Lookup API', () => {
   });
 
   it('returns summary counts', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'A' } }) })
-      .mockResolvedValueOnce({ ok: false, json: async () => ({ error: 'fail' }) });
+    vi.mocked(handleUrl).mockResolvedValueOnce(NextResponse.json({ data: { title: 'A' } }, { status: 200 }));
+    vi.mocked(handleDoi).mockResolvedValueOnce(NextResponse.json({ error: 'fail' }, { status: 500 }));
     const response = await POST(
       makeRequest({ items: ['https://success.com', '10.1000/fail'] })
     );
@@ -115,9 +113,8 @@ describe('Bulk Lookup API', () => {
   });
 
   it('handles mixed item types in one batch', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'URL result' } }) })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'DOI result' } }) });
+    vi.mocked(handleUrl).mockResolvedValueOnce(NextResponse.json({ data: { title: 'URL result' } }, { status: 200 }));
+    vi.mocked(handleDoi).mockResolvedValueOnce(NextResponse.json({ data: { title: 'DOI result' } }, { status: 200 }));
     const response = await POST(
       makeRequest({ items: ['https://example.com', '10.1000/abc'] })
     );

--- a/src/app/api/lookup/bulk/route.ts
+++ b/src/app/api/lookup/bulk/route.ts
@@ -1,4 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { POST as handleUrl } from "../url/route";
+import { POST as handleDoi } from "../doi/route";
+import { POST as handleIsbn } from "../isbn/route";
 
 interface LookupResult {
   input: string;
@@ -21,9 +24,6 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Maximum 20 items allowed per request" }, { status: 400 });
     }
 
-    // Refactored to process lookups concurrently for performance improvement
-    const baseUrl = request.nextUrl.origin;
-
     const lookupPromises = items.map(async (item) => {
       const trimmedItem = item.trim();
       if (!trimmedItem) {
@@ -31,19 +31,19 @@ export async function POST(request: NextRequest) {
       }
 
       try {
-        let apiEndpoint: string;
-        let body: object;
+        let handler: (req: NextRequest) => Promise<NextResponse>;
+        let reqBody: object;
 
         // Detect input type
         if (trimmedItem.match(/^(https?:\/\/|www\.)/i)) {
-          apiEndpoint = "/api/lookup/url";
-          body = { url: trimmedItem };
+          handler = handleUrl;
+          reqBody = { url: trimmedItem };
         } else if (trimmedItem.match(/^10\.\d{4,}/)) {
-          apiEndpoint = "/api/lookup/doi";
-          body = { doi: trimmedItem };
+          handler = handleDoi;
+          reqBody = { doi: trimmedItem };
         } else if (trimmedItem.match(/^(97[89])?\d{9}[\dXx]$/)) {
-          apiEndpoint = "/api/lookup/isbn";
-          body = { isbn: trimmedItem };
+          handler = handleIsbn;
+          reqBody = { isbn: trimmedItem };
         } else {
           return {
             input: trimmedItem,
@@ -52,13 +52,14 @@ export async function POST(request: NextRequest) {
           };
         }
 
-        // Make the API call
-        const response = await fetch(`${baseUrl}${apiEndpoint}`, {
+        // Make the direct handler call instead of HTTP fetch to prevent SSRF
+        const mockRequest = new NextRequest(new URL(request.url), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(body),
+          body: JSON.stringify(reqBody),
         });
 
+        const response = await handler(mockRequest);
         const data = await response.json();
 
         if (response.ok && data.data) {


### PR DESCRIPTION
This PR mitigates a critical Server-Side Request Forgery (SSRF) vulnerability inside the `/api/lookup/bulk` API route.

🚨 **Severity:** HIGH
💡 **Vulnerability:** The bulk API endpoint dynamically constructed internal loopback fetch requests using `request.nextUrl.origin`, which is automatically populated from the incoming HTTP `Host` header. Because the `Host` header is fully attacker-controllable (or injectable via `X-Forwarded-Host`), an attacker could instruct the API to send internal lookup requests—alongside associated metadata and application headers—to an arbitrary external server or, critically, to an internal private port bypassing other boundary restrictions.
🎯 **Impact:** Exposes internal infrastructure requests to external attackers or loops attacks against the local environment (e.g. `127.0.0.1:9090`).
🔧 **Fix:** Replaced the HTTP `fetch()` loopback with direct internal Next.js Route Handler invocations (`POST` functions imported directly from the URL, DOI, and ISBN endpoint files). This completely sidesteps HTTP networking for internal actions, thus preventing Host-header-based URL fabrication.
✅ **Verification:** Unit tests have been refactored and updated. The entire `pnpm test` and `pnpm lint` suites pass. Validated visually and network-layer that the external networking payload is no longer possible.

---
*PR created automatically by Jules for task [13293873321544520731](https://jules.google.com/task/13293873321544520731) started by @aicoder2009*