### PR TITLE
⚡ Bolt: derive project lists in memory to avoid redundant API fetches

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Concurrent Fetching with Owner IDs in Share Links
 **Learning:** In the share system, endpoints processing a share code typically suffer from waterfall latency by first loading target entity details (like a project) and then querying its associated elements (like project lists) using the entity's owner ID (`userId`). However, the `shareLink` object already contains the `userId` field (representing the owner's ID).
 **Action:** Always leverage the existing owner's ID within `shareLink` to bypass sequential dependencies and fetch parent entities (like projects) concurrently with their child elements (like user lists) using `Promise.all`.
+
+## 2025-02-12 - Derive Subsets in Memory to Avoid Redundant Requests
+**Learning:** When fetching a global collection (like "all lists") alongside a subset of that collection (like "lists for a specific project"), fetching both from the API leads to redundant database scans and unnecessary network overhead. The backend for the subset often fetches everything to filter it anyway.
+**Action:** When a global collection and a subset are both needed, only fetch the global collection (e.g. `/api/lists`) and derive the subset in memory on the client side using array filtering (`globalCollection.filter(...)`).

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -60,15 +60,13 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       // OPTIMIZATION: Execute independent network requests and JSON parsing concurrently
       // using Promise.all. This prevents a 3-step waterfall, reducing Time to First Byte
       // (TTFB) and overall load time significantly on this detail page.
-      const [projectRes, listsRes, allListsRes] = await Promise.all([
+      const [projectRes, allListsRes] = await Promise.all([
         fetch(`/api/projects/${projectId}`),
-        fetch(`/api/projects/${projectId}/lists`),
         fetch("/api/lists"),
       ]);
 
-      const [projectResult, listsResult, allListsResult] = await Promise.all([
+      const [projectResult, allListsResult] = await Promise.all([
         projectRes.json(),
-        listsRes.json(),
         allListsRes.json(),
       ]);
 
@@ -81,12 +79,11 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setEditName(projectResult.data.name);
       setEditDescription(projectResult.data.description || "");
 
-      if (listsResult.success) {
-        setLists(listsResult.data);
-      }
-
       if (allListsResult.success) {
-        setAllLists(allListsResult.data);
+        const allListsData: List[] = allListsResult.data;
+        setAllLists(allListsData);
+        // Derive project lists from all lists to avoid redundant API requests
+        setLists(allListsData.filter((list) => list.projectId === projectId));
       }
     } catch (err) {
       console.error("Error fetching project:", err);


### PR DESCRIPTION
💡 What: Replaced the redundant API request to `/api/projects/${projectId}/lists` with a client-side in-memory filter of the global `allListsResult` in `src/app/projects/[id]/page.tsx`.

🎯 Why: The page was fetching all lists and a subset of lists concurrently. Since the backend query for the subset effectively scans all the user's lists and filters them anyway, fetching it from the API while also fetching all lists is redundant and causes unnecessary network overhead and duplicate database queries.

📊 Impact: Eliminates 1 HTTP API request per project page load. Reduces DynamoDB capacity consumption by avoiding a redundant table scan/query for the same dataset.

🔬 Measurement: Verify network requests in DevTools when loading a project detail page. You should only see `fetch(/api/projects/[id])` and `fetch(/api/lists)` instead of the previous 3 waterfall queries. All tests still pass correctly.

---
*PR created automatically by Jules for task [13525678629074270739](https://jules.google.com/task/13525678629074270739) started by @aicoder2009*