### PR TITLE
⚡ Bolt: Derive project lists in-memory to prevent redundant API request

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Concurrent Fetching with Owner IDs in Share Links
 **Learning:** In the share system, endpoints processing a share code typically suffer from waterfall latency by first loading target entity details (like a project) and then querying its associated elements (like project lists) using the entity's owner ID (`userId`). However, the `shareLink` object already contains the `userId` field (representing the owner's ID).
 **Action:** Always leverage the existing owner's ID within `shareLink` to bypass sequential dependencies and fetch parent entities (like projects) concurrently with their child elements (like user lists) using `Promise.all`.
+
+## 2024-05-30 - In-Memory Derivation of Subset Data
+**Learning:** When a page concurrently fetches both a complete global collection (e.g., all lists for a user) and a specific subset of that same collection (e.g., lists associated with a specific project), the subset API request is redundant and creates unnecessary backend database load and network traffic.
+**Action:** Always derive the subset data in-memory using array filtering (e.g., `allData.filter(item => item.parentId === parentId)`) instead of executing a duplicate, overlapping API fetch request.

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -60,15 +60,13 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       // OPTIMIZATION: Execute independent network requests and JSON parsing concurrently
       // using Promise.all. This prevents a 3-step waterfall, reducing Time to First Byte
       // (TTFB) and overall load time significantly on this detail page.
-      const [projectRes, listsRes, allListsRes] = await Promise.all([
+      const [projectRes, allListsRes] = await Promise.all([
         fetch(`/api/projects/${projectId}`),
-        fetch(`/api/projects/${projectId}/lists`),
         fetch("/api/lists"),
       ]);
 
-      const [projectResult, listsResult, allListsResult] = await Promise.all([
+      const [projectResult, allListsResult] = await Promise.all([
         projectRes.json(),
-        listsRes.json(),
         allListsRes.json(),
       ]);
 
@@ -81,12 +79,10 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setEditName(projectResult.data.name);
       setEditDescription(projectResult.data.description || "");
 
-      if (listsResult.success) {
-        setLists(listsResult.data);
-      }
-
       if (allListsResult.success) {
         setAllLists(allListsResult.data);
+        // OPTIMIZATION: Derive project lists in-memory to avoid redundant API request
+        setLists(allListsResult.data.filter((list: List) => list.projectId === projectId));
       }
     } catch (err) {
       console.error("Error fetching project:", err);


### PR DESCRIPTION
💡 What: Removed a redundant `/api/projects/[id]/lists` network request in `src/app/projects/[id]/page.tsx` by deriving the project-specific lists directly in-memory from the globally fetched `allListsResult.data`.
🎯 Why: The page previously fetched both the complete set of a user's lists and a specific subset of those lists simultaneously. This generated an unnecessary redundant backend API request and database query.
📊 Impact: Reduces network requests by 33% on the project detail page load, decreasing redundant backend computation and slightly lowering Time to First Byte (TTFB).
🔬 Measurement: Verify that loading the project details page triggers only two data fetching endpoints (`/api/projects/[id]` and `/api/lists`), not three.

---
*PR created automatically by Jules for task [16313201661836235732](https://jules.google.com/task/16313201661836235732) started by @aicoder2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized project details page data retrieval to reduce API requests by consolidating list data fetching and deriving project-specific lists client-side for improved performance.

* **Chores**
  * Added internal development guidelines for efficient in-memory data derivation patterns to minimize redundant API requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aicoder2009/opencitation/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->