### PR TITLE
⚡ Bolt: Eliminate redundant API request for project lists

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Concurrent Fetching with Owner IDs in Share Links
 **Learning:** In the share system, endpoints processing a share code typically suffer from waterfall latency by first loading target entity details (like a project) and then querying its associated elements (like project lists) using the entity's owner ID (`userId`). However, the `shareLink` object already contains the `userId` field (representing the owner's ID).
 **Action:** Always leverage the existing owner's ID within `shareLink` to bypass sequential dependencies and fetch parent entities (like projects) concurrently with their child elements (like user lists) using `Promise.all`.
+
+## 2024-05-19 - [Redundant Frontend API Queries]
+**Learning:** Fetching a global collection (e.g., all lists) and a subset of that collection (e.g., project lists) simultaneously on the frontend via separate API requests leads to duplicate backend database queries and unnecessary network overhead.
+**Action:** When fetching a global collection and a subset on the frontend, derive the subset in-memory using array filtering instead of making a redundant API request.

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -58,17 +58,17 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setIsLoading(true);
 
       // OPTIMIZATION: Execute independent network requests and JSON parsing concurrently
-      // using Promise.all. This prevents a 3-step waterfall, reducing Time to First Byte
-      // (TTFB) and overall load time significantly on this detail page.
-      const [projectRes, listsRes, allListsRes] = await Promise.all([
+      // using Promise.all. This prevents a waterfall, reducing Time to First Byte (TTFB).
+      // Furthermore, since we fetch all lists for the project adding/editing UI, we can
+      // derive the project's specific lists in-memory rather than making a redundant
+      // /api/projects/[id]/lists API request, avoiding an unnecessary backend database query.
+      const [projectRes, allListsRes] = await Promise.all([
         fetch(`/api/projects/${projectId}`),
-        fetch(`/api/projects/${projectId}/lists`),
         fetch("/api/lists"),
       ]);
 
-      const [projectResult, listsResult, allListsResult] = await Promise.all([
+      const [projectResult, allListsResult] = await Promise.all([
         projectRes.json(),
-        listsRes.json(),
         allListsRes.json(),
       ]);
 
@@ -81,12 +81,10 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setEditName(projectResult.data.name);
       setEditDescription(projectResult.data.description || "");
 
-      if (listsResult.success) {
-        setLists(listsResult.data);
-      }
-
       if (allListsResult.success) {
-        setAllLists(allListsResult.data);
+        const listsData = allListsResult.data as List[];
+        setAllLists(listsData);
+        setLists(listsData.filter((list) => list.projectId === projectId));
       }
     } catch (err) {
       console.error("Error fetching project:", err);


### PR DESCRIPTION
💡 **What**: Eliminated the `/api/projects/[id]/lists` network request on the project detail page by filtering the global `allLists` result in-memory.
🎯 **Why**: The frontend previously fetched a global collection (`allLists`) and its subset (`lists`) simultaneously via separate API requests. Since `allLists` already contained the required data, the secondary request caused unnecessary network overhead and an extra database query. 
📊 **Impact**: Reduces backend database queries, prevents redundant network latency, and marginally decreases Time to First Byte (TTFB).
🔬 **Measurement**: Verified by ensuring all tests pass (`pnpm test:run`), frontend loads correctly without throwing errors, and by monitoring Network tab behaviour (expecting 1 fewer request to `/api/projects/[id]/lists`).

---
*PR created automatically by Jules for task [4954961390721112058](https://jules.google.com/task/4954961390721112058) started by @aicoder2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized project detail page load performance by fetching project details and lists concurrently, then filtering in-memory to eliminate redundant API calls.

* **Documentation**
  * Added best practice documentation for efficient frontend data-fetching strategies using in-memory filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->