### PR TITLE
⚡ Bolt: Eliminate redundant API request on project detail page

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Concurrent Fetching with Owner IDs in Share Links
 **Learning:** In the share system, endpoints processing a share code typically suffer from waterfall latency by first loading target entity details (like a project) and then querying its associated elements (like project lists) using the entity's owner ID (`userId`). However, the `shareLink` object already contains the `userId` field (representing the owner's ID).
 **Action:** Always leverage the existing owner's ID within `shareLink` to bypass sequential dependencies and fetch parent entities (like projects) concurrently with their child elements (like user lists) using `Promise.all`.
+
+## 2024-05-19 - [In-memory filtering for global subsets]
+**Learning:** When a UI component requires both a global collection (e.g., all lists for the user) and a subset of that collection (e.g., lists associated with a specific project), making two separate API requests causes redundant database queries and increases network payload size.
+**Action:** When a subset can be perfectly derived from a global collection that is already being fetched, derive the subset in-memory using array filtering (`Array.prototype.filter()`) instead of executing an additional backend request. This eliminates a duplicate network call and database query.

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -60,15 +60,15 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       // OPTIMIZATION: Execute independent network requests and JSON parsing concurrently
       // using Promise.all. This prevents a 3-step waterfall, reducing Time to First Byte
       // (TTFB) and overall load time significantly on this detail page.
-      const [projectRes, listsRes, allListsRes] = await Promise.all([
+      // Furthermore, instead of making a redundant backend query for the project's lists,
+      // we derive them in-memory by filtering the global lists collection.
+      const [projectRes, allListsRes] = await Promise.all([
         fetch(`/api/projects/${projectId}`),
-        fetch(`/api/projects/${projectId}/lists`),
         fetch("/api/lists"),
       ]);
 
-      const [projectResult, listsResult, allListsResult] = await Promise.all([
+      const [projectResult, allListsResult] = await Promise.all([
         projectRes.json(),
-        listsRes.json(),
         allListsRes.json(),
       ]);
 
@@ -81,12 +81,13 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setEditName(projectResult.data.name);
       setEditDescription(projectResult.data.description || "");
 
-      if (listsResult.success) {
-        setLists(listsResult.data);
-      }
-
       if (allListsResult.success) {
-        setAllLists(allListsResult.data);
+        const globalLists = allListsResult.data as List[];
+        setAllLists(globalLists);
+
+        // Derive the project-specific lists in-memory to avoid an extra API request
+        const projectLists = globalLists.filter(list => list.projectId === projectId);
+        setLists(projectLists);
       }
     } catch (err) {
       console.error("Error fetching project:", err);


### PR DESCRIPTION
## 💡 What: The optimization implemented
Removed a redundant network call (`/api/projects/[id]/lists`) in the Project details page (`src/app/projects/[id]/page.tsx`). The lists belonging to the current project are now derived in-memory by filtering the `allLists` array (fetched via `/api/lists`).

## 🎯 Why: The performance problem it solves
The page was previously making two independent database queries (and network requests) to fetch list data: one for *all* lists (`getUserLists`) and another specifically for the *project's* lists (`getProjectLists`, which itself calls `getUserLists` backend-side and filters). This caused duplicate database lookups and unnecessarily increased the payload size over the network.

## 📊 Impact
- Reduces database reads by eliminating the duplicate `getUserLists` call on the backend.
- Eliminates 1 outgoing network request (reducing bandwidth).
- Saves frontend processing time by preventing an extra JSON parsing step.

## 🔬 Measurement
Load the project detail page and monitor the Network tab. You will now observe only 2 concurrent API requests (`/api/projects/[id]` and `/api/lists`) instead of 3, while preserving all existing functionality and rendering.

---
*PR created automatically by Jules for task [12385135960809278255](https://jules.google.com/task/12385135960809278255) started by @aicoder2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added performance guidance for handling global datasets and derived subsets via client-side filtering.

* **Performance**
  * Optimized data fetching by eliminating redundant API requests; project-specific data is now derived client-side from global datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->