### PR TITLE
⚡ Bolt: Deduplicate subset data fetching in project details

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Concurrent Fetching with Owner IDs in Share Links
 **Learning:** In the share system, endpoints processing a share code typically suffer from waterfall latency by first loading target entity details (like a project) and then querying its associated elements (like project lists) using the entity's owner ID (`userId`). However, the `shareLink` object already contains the `userId` field (representing the owner's ID).
 **Action:** Always leverage the existing owner's ID within `shareLink` to bypass sequential dependencies and fetch parent entities (like projects) concurrently with their child elements (like user lists) using `Promise.all`.
+
+## 2024-06-03 - [Deduplicate Subset Data Fetching]
+**Learning:** Fetching a subset collection (e.g., project-specific lists) directly from the backend while simultaneously fetching its parent global collection (e.g., all lists) results in redundant database queries and unnecessary network load. This is an anti-pattern.
+**Action:** When a global collection and its specific subset are needed on the frontend concurrently, fetch only the global collection and derive the subset in-memory using array filtering.

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -58,17 +58,17 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setIsLoading(true);
 
       // OPTIMIZATION: Execute independent network requests and JSON parsing concurrently
-      // using Promise.all. This prevents a 3-step waterfall, reducing Time to First Byte
+      // using Promise.all. This prevents a waterfall, reducing Time to First Byte
       // (TTFB) and overall load time significantly on this detail page.
-      const [projectRes, listsRes, allListsRes] = await Promise.all([
+      // FURTHER OPTIMIZATION: Avoid duplicate backend queries by deriving project-specific
+      // lists from the global 'allListsRes' in-memory, rather than making a redundant fetch.
+      const [projectRes, allListsRes] = await Promise.all([
         fetch(`/api/projects/${projectId}`),
-        fetch(`/api/projects/${projectId}/lists`),
         fetch("/api/lists"),
       ]);
 
-      const [projectResult, listsResult, allListsResult] = await Promise.all([
+      const [projectResult, allListsResult] = await Promise.all([
         projectRes.json(),
-        listsRes.json(),
         allListsRes.json(),
       ]);
 
@@ -81,12 +81,10 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setEditName(projectResult.data.name);
       setEditDescription(projectResult.data.description || "");
 
-      if (listsResult.success) {
-        setLists(listsResult.data);
-      }
-
       if (allListsResult.success) {
         setAllLists(allListsResult.data);
+        // Filter in-memory to get project lists
+        setLists(allListsResult.data.filter((list: List) => list.projectId === projectId));
       }
     } catch (err) {
       console.error("Error fetching project:", err);


### PR DESCRIPTION
⚡ Bolt: Deduplicate Subset Data Fetching

💡 **What:** Eliminated the redundant loopback HTTP call (`fetch('/api/projects/${projectId}/lists')`) inside the project detail view (`src/app/projects/[id]/page.tsx`). The lists belonging to the project are now derived in-memory by filtering the `allListsRes` object. 
🎯 **Why:** The detail page was previously fetching both the global list collection (all a user's lists) and a specific subset of lists (those belonging to the current project) from the backend at the same time. Since the API does not currently use GSIs to narrow down projects rapidly, this created a redundant read loop on the backend.
📊 **Impact:** Reduces redundant HTTP requests by 1 per project detail view load, saves duplicate backend DynamoDB query processing cycles, and contributes to lowered Time to First Byte (TTFB).
🔬 **Measurement:** Verify by visiting a project detail page and inspecting the network tab – you'll observe two `fetch` calls (`/api/projects/[id]` and `/api/lists`) instead of three, while the UI accurately reflects project-associated lists versus unassociated lists available to be added.

---
*PR created automatically by Jules for task [8125695675951932664](https://jules.google.com/task/8125695675951932664) started by @aicoder2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved data fetching efficiency by reducing network requests. The application now fetches the complete collection once and derives project-specific subsets locally through in-memory filtering, enhancing performance while maintaining consistent error handling and user experience.

* **Documentation**
  * Added documentation describing optimized data-fetching patterns and anti-patterns to avoid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->