### PR TITLE
🛡️ Sentinel: [HIGH] Fix Missing CSRF Protection on Mutating API Routes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** The application was using the `marked` library to parse Markdown content into HTML (in `src/app/docs/changelog/page.tsx` and `src/lib/docs.ts`) and subsequently rendering it using `dangerouslySetInnerHTML` without proper sanitization.
 **Learning:** `marked` does not sanitize HTML by default. While this may seem safe for trusted inputs (like internal docs or GitHub releases), if malicious input manages to enter these sources, it leads directly to an XSS vulnerability.
 **Prevention:** The output of `marked` (or any markdown parser) must always be wrapped with `DOMPurify.sanitize()` (using `isomorphic-dompurify` for SSR) before being passed to `dangerouslySetInnerHTML`.
+
+## 2024-06-03 - Missing CSRF Protection on Mutating API Routes
+**Vulnerability:** Several authenticated POST endpoints (e.g., creating lists, citations, projects, and share links) were missing the `isSameOrigin` check, leaving them vulnerable to Cross-Site Request Forgery (CSRF). While `stats/increment` was protected, core mutating routes were not.
+**Learning:** Next.js Route Handlers do not automatically protect against CSRF attacks. Although Clerk provides authentication, an attacker could still forge cross-origin POST requests on behalf of an authenticated user to perform state mutations unless the Origin/Referer headers are explicitly validated against the host.
+**Prevention:** Always enforce an `isSameOrigin` validation check (or use proper CSRF tokens) on all authenticated, state-mutating API routes (POST, PUT, DELETE, PATCH). Read-only or lookup routes without state mutation typically do not require it.

--- a/src/app/api/lists/[id]/citations/route.test.ts
+++ b/src/app/api/lists/[id]/citations/route.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET, POST } from "./route";
 import { NextRequest } from "next/server";
 
+vi.mock("@/lib/security/rate-limit", () => ({
+  isSameOrigin: vi.fn(() => true),
+}));
+
 // Mock Clerk auth
 vi.mock("@clerk/nextjs/server", () => ({
   auth: vi.fn(),

--- a/src/app/api/lists/[id]/citations/route.ts
+++ b/src/app/api/lists/[id]/citations/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@clerk/nextjs/server";
 import { getList, getListCitations, addCitation } from "@/lib/db";
 import type { CitationFields, CitationStyle } from "@/types";
 import { getPostHogClient } from "@/lib/posthog-server";
+import { isSameOrigin } from "@/lib/security/rate-limit";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -56,6 +57,10 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         { success: false, error: "Unauthorized" },
         { status: 401 }
       );
+    }
+
+    if (!isSameOrigin(request)) {
+      return NextResponse.json({ success: false, error: "Forbidden" }, { status: 403 });
     }
 
     // Verify the list exists and belongs to the user

--- a/src/app/api/lists/route.test.ts
+++ b/src/app/api/lists/route.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET, POST } from "./route";
 import { NextRequest } from "next/server";
 
+vi.mock("@/lib/security/rate-limit", () => ({
+  isSameOrigin: vi.fn(() => true),
+}));
+
 // Mock Clerk auth
 vi.mock("@clerk/nextjs/server", () => ({
   auth: vi.fn(),

--- a/src/app/api/lists/route.ts
+++ b/src/app/api/lists/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { createList, getUserLists } from "@/lib/db";
 import { isListNameTaken } from "@/lib/db/validation";
+import { isSameOrigin } from "@/lib/security/rate-limit";
 
 // GET /api/lists - Get all lists for the authenticated user
 export async function GET() {
@@ -40,6 +41,10 @@ export async function POST(request: NextRequest) {
         { success: false, error: "Unauthorized" },
         { status: 401 }
       );
+    }
+
+    if (!isSameOrigin(request)) {
+      return NextResponse.json({ success: false, error: "Forbidden" }, { status: 403 });
     }
 
     const body = await request.json();

--- a/src/app/api/projects/[id]/lists/route.test.ts
+++ b/src/app/api/projects/[id]/lists/route.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET, POST } from "./route";
 import { NextRequest } from "next/server";
 
+vi.mock("@/lib/security/rate-limit", () => ({
+  isSameOrigin: vi.fn(() => true),
+}));
+
 // Mock Clerk auth
 vi.mock("@clerk/nextjs/server", () => ({
   auth: vi.fn(),

--- a/src/app/api/projects/[id]/lists/route.ts
+++ b/src/app/api/projects/[id]/lists/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { getProject, getProjectLists, createList } from "@/lib/db";
 import { isListNameTaken } from "@/lib/db/validation";
+import { isSameOrigin } from "@/lib/security/rate-limit";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -55,6 +56,10 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         { success: false, error: "Unauthorized" },
         { status: 401 }
       );
+    }
+
+    if (!isSameOrigin(request)) {
+      return NextResponse.json({ success: false, error: "Forbidden" }, { status: 403 });
     }
 
     // Verify the project exists and belongs to the user

--- a/src/app/api/projects/route.test.ts
+++ b/src/app/api/projects/route.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET, POST } from "./route";
 import { NextRequest } from "next/server";
 
+vi.mock("@/lib/security/rate-limit", () => ({
+  isSameOrigin: vi.fn(() => true),
+}));
+
 // Mock Clerk auth
 vi.mock("@clerk/nextjs/server", () => ({
   auth: vi.fn(),

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { createProject, getUserProjects } from "@/lib/db";
 import { isProjectNameTaken } from "@/lib/db/validation";
+import { isSameOrigin } from "@/lib/security/rate-limit";
 
 // GET /api/projects - Get all projects for the current user
 export async function GET() {
@@ -40,6 +41,10 @@ export async function POST(request: NextRequest) {
         { success: false, error: "Unauthorized" },
         { status: 401 }
       );
+    }
+
+    if (!isSameOrigin(request)) {
+      return NextResponse.json({ success: false, error: "Forbidden" }, { status: 403 });
     }
 
     const body = await request.json();

--- a/src/app/api/share/[code]/clone/route.ts
+++ b/src/app/api/share/[code]/clone/route.ts
@@ -15,9 +15,11 @@ import {
 } from "@/lib/db";
 import { parseShareSegment } from "@/lib/share-utils";
 import { verifySharePassword } from "@/lib/share-password";
+import { isSameOrigin } from "@/lib/security/rate-limit";
+import { NextRequest } from "next/server";
 
 export async function POST(
-  req: Request,
+  req: NextRequest,
   { params }: { params: Promise<{ code: string }> }
 ) {
   const { userId } = await auth();
@@ -26,6 +28,10 @@ export async function POST(
       { success: false, error: "Sign in to save" },
       { status: 401 }
     );
+  }
+
+  if (!isSameOrigin(req)) {
+    return NextResponse.json({ success: false, error: "Forbidden" }, { status: 403 });
   }
 
   const { code: segment } = await params;

--- a/src/app/api/share/route.test.ts
+++ b/src/app/api/share/route.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET, POST } from "./route";
 import { NextRequest } from "next/server";
 
+vi.mock("@/lib/security/rate-limit", () => ({
+  isSameOrigin: vi.fn(() => true),
+  rateLimit: vi.fn(() => ({ ok: true })),
+  getClientKey: vi.fn(),
+}));
+
 // Mock Clerk auth
 vi.mock("@clerk/nextjs/server", () => ({
   auth: vi.fn(),

--- a/src/app/api/share/route.ts
+++ b/src/app/api/share/route.ts
@@ -12,6 +12,7 @@ import {
 import { getPostHogClient } from "@/lib/posthog-server";
 import { buildShareSegment, slugify } from "@/lib/share-utils";
 import { hashSharePassword } from "@/lib/share-password";
+import { isSameOrigin } from "@/lib/security/rate-limit";
 
 // GET /api/share - List active share links owned by the current user
 export async function GET() {
@@ -76,6 +77,10 @@ export async function POST(request: NextRequest) {
         { success: false, error: "Unauthorized" },
         { status: 401 }
       );
+    }
+
+    if (!isSameOrigin(request)) {
+      return NextResponse.json({ success: false, error: "Forbidden" }, { status: 403 });
     }
 
     const body = await request.json();


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Next.js Route Handlers do not automatically protect against CSRF attacks. Several core authenticated POST endpoints (creating lists, projects, citations, and share links) lacked the `isSameOrigin` check, meaning an attacker could potentially forge a cross-origin request using an authenticated user's session to perform unauthorized state mutations.
🎯 **Impact:** An attacker could trick a logged-in user into visiting a malicious site that sends POST requests to the OpenCitation API, creating lists, projects, or share links without their explicit consent.
🔧 **Fix:** Imported and enforced the existing `isSameOrigin` utility check from `@/lib/security/rate-limit.ts` to block cross-origin POSTs across all vulnerable endpoints, returning a `403 Forbidden` response.
✅ **Verification:** Verified via `pnpm test` (tests updated with mocked CSRF check) and visual inspection of route handlers.

---
*PR created automatically by Jules for task [8950450425632066895](https://jules.google.com/task/8950450425632066895) started by @aicoder2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API endpoints now include origin validation checks on all POST operations throughout the application. Requests from invalid origin sources receive a 403 Forbidden response. This validation applies to project creation, list management, citation handling, and content sharing features.

* **Tests**
  * Updated test suite infrastructure with proper mocking for request origin validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->