### PR TITLE
⚡ Bolt: Eliminate redundant API call by deriving project lists in-memory

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Concurrent Fetching with Owner IDs in Share Links
 **Learning:** In the share system, endpoints processing a share code typically suffer from waterfall latency by first loading target entity details (like a project) and then querying its associated elements (like project lists) using the entity's owner ID (`userId`). However, the `shareLink` object already contains the `userId` field (representing the owner's ID).
 **Action:** Always leverage the existing owner's ID within `shareLink` to bypass sequential dependencies and fetch parent entities (like projects) concurrently with their child elements (like user lists) using `Promise.all`.
+
+## 2024-05-19 - [In-Memory Derivation of Subsets]
+**Learning:** Fetching a global collection (e.g., all lists for a user) and a subset of that collection (e.g., lists for a specific project) concurrently via separate API requests results in redundant database queries and network overhead.
+**Action:** When a global collection and its subset are both needed on the frontend, fetch only the global collection and derive the subset in-memory using array filtering. This eliminates redundant API calls and database queries, improving efficiency.

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -58,17 +58,16 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setIsLoading(true);
 
       // OPTIMIZATION: Execute independent network requests and JSON parsing concurrently
-      // using Promise.all. This prevents a 3-step waterfall, reducing Time to First Byte
+      // using Promise.all. This prevents a waterfall, reducing Time to First Byte
       // (TTFB) and overall load time significantly on this detail page.
-      const [projectRes, listsRes, allListsRes] = await Promise.all([
+      // We also derive project lists in-memory from allLists to avoid a redundant API call.
+      const [projectRes, allListsRes] = await Promise.all([
         fetch(`/api/projects/${projectId}`),
-        fetch(`/api/projects/${projectId}/lists`),
         fetch("/api/lists"),
       ]);
 
-      const [projectResult, listsResult, allListsResult] = await Promise.all([
+      const [projectResult, allListsResult] = await Promise.all([
         projectRes.json(),
-        listsRes.json(),
         allListsRes.json(),
       ]);
 
@@ -81,12 +80,11 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setEditName(projectResult.data.name);
       setEditDescription(projectResult.data.description || "");
 
-      if (listsResult.success) {
-        setLists(listsResult.data);
-      }
-
       if (allListsResult.success) {
         setAllLists(allListsResult.data);
+        // Derive project-specific lists in-memory
+        const projectLists = allListsResult.data.filter((list: List) => list.projectId === projectId);
+        setLists(projectLists);
       }
     } catch (err) {
       console.error("Error fetching project:", err);


### PR DESCRIPTION
💡 What: Removed a redundant API call that fetched a subset of lists (a project's lists) by deriving it in-memory from a globally fetched collection of all lists.
🎯 Why: When `fetchProjectAndLists` runs on the project detail page, it was simultaneously calling `/api/lists` and `/api/projects/[id]/lists`. This is a redundant backend request and database query, as the user's total list collection inherently contains the project's subset.
📊 Impact: Saves an entire HTTP network round-trip and an extra DynamoDB query on load, improving efficiency and reducing Time to First Byte (TTFB).
🔬 Measurement: Verify network tabs in devtools; there should only be requests for the project details and all lists, not a third request for project lists.

---
*PR created automatically by Jules for task [5639755679843157172](https://jules.google.com/task/5639755679843157172) started by @aicoder2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced project page performance by streamlining data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->