### PR TITLE
⚡ Bolt: Remove redundant network fetch for project lists by filtering global lists in-memory

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Concurrent Fetching with Owner IDs in Share Links
 **Learning:** In the share system, endpoints processing a share code typically suffer from waterfall latency by first loading target entity details (like a project) and then querying its associated elements (like project lists) using the entity's owner ID (`userId`). However, the `shareLink` object already contains the `userId` field (representing the owner's ID).
 **Action:** Always leverage the existing owner's ID within `shareLink` to bypass sequential dependencies and fetch parent entities (like projects) concurrently with their child elements (like user lists) using `Promise.all`.
+
+## 2024-05-19 - Filter Subsets In-Memory
+**Learning:** When a page needs both a global collection of elements (e.g., all lists) and a subset of that collection (e.g., lists associated with a specific project) at the same time, executing separate API requests to fetch both is a redundant operation that increases backend load and slightly delays TTFB. This redundant request pattern happens because React pages often treat endpoint APIs as fully isolated units of work.
+**Action:** When a global collection and a subset are both required on the same page, request only the global collection and derive the subset locally in-memory using array filtering. Always verify if an API call for a subset is redundant before implementing it.

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -60,15 +60,15 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       // OPTIMIZATION: Execute independent network requests and JSON parsing concurrently
       // using Promise.all. This prevents a 3-step waterfall, reducing Time to First Byte
       // (TTFB) and overall load time significantly on this detail page.
-      const [projectRes, listsRes, allListsRes] = await Promise.all([
+      // FURTHER OPTIMIZATION: Instead of making a redundant API request to /api/projects/[id]/lists,
+      // we derive the project's lists in-memory from the global /api/lists collection.
+      const [projectRes, allListsRes] = await Promise.all([
         fetch(`/api/projects/${projectId}`),
-        fetch(`/api/projects/${projectId}/lists`),
         fetch("/api/lists"),
       ]);
 
-      const [projectResult, listsResult, allListsResult] = await Promise.all([
+      const [projectResult, allListsResult] = await Promise.all([
         projectRes.json(),
-        listsRes.json(),
         allListsRes.json(),
       ]);
 
@@ -81,12 +81,10 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setEditName(projectResult.data.name);
       setEditDescription(projectResult.data.description || "");
 
-      if (listsResult.success) {
-        setLists(listsResult.data);
-      }
-
       if (allListsResult.success) {
         setAllLists(allListsResult.data);
+        // Filter the lists in-memory for this project to save an API request
+        setLists(allListsResult.data.filter((list: List) => list.projectId === projectId));
       }
     } catch (err) {
       console.error("Error fetching project:", err);


### PR DESCRIPTION
💡 What: Modified `src/app/projects/[id]/page.tsx` to stop making an extra, redundant API request to `/api/projects/[id]/lists`. Instead, the application now derives this subset in-memory by filtering the global response from `/api/lists` (which is already being fetched concurrently).

🎯 Why: To reduce redundant network requests, decrease backend load, and slightly improve TTFB by not making the database run an isolated query for a subset of data that the client already receives globally in the same component.

📊 Impact: 
- Eliminates 1 HTTP request and 1 database read (per project detail page view).

🔬 Measurement: 
- Load a Project details page in the browser and monitor the Network tab.
- Observe that `/api/lists` is called, but `/api/projects/[id]/lists` is no longer called, while the project lists still render correctly in the UI.

Added a reflection on this codebase-specific anti-pattern to `.jules/bolt.md`.

---
*PR created automatically by Jules for task [3159117257274641856](https://jules.google.com/task/3159117257274641856) started by @aicoder2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on efficient API usage patterns.

* **Refactor**
  * Optimized data loading on project detail page to reduce redundant API calls by fetching data once and filtering in-memory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->