### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF loopback vulnerability in bulk lookup API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** The application was using the `marked` library to parse Markdown content into HTML (in `src/app/docs/changelog/page.tsx` and `src/lib/docs.ts`) and subsequently rendering it using `dangerouslySetInnerHTML` without proper sanitization.
 **Learning:** `marked` does not sanitize HTML by default. While this may seem safe for trusted inputs (like internal docs or GitHub releases), if malicious input manages to enter these sources, it leads directly to an XSS vulnerability.
 **Prevention:** The output of `marked` (or any markdown parser) must always be wrapped with `DOMPurify.sanitize()` (using `isomorphic-dompurify` for SSR) before being passed to `dangerouslySetInnerHTML`.
+
+## 2024-06-07 - SSRF via Host-header in Next.js Loopback APIs
+**Vulnerability:** Bulk API endpoint `src/app/api/lookup/bulk/route.ts` used `request.nextUrl.origin` to construct an absolute URL for a `fetch` call to other internal APIs. Since `request.nextUrl.origin` is derived from the HTTP `Host` header sent by the client, an attacker could spoof the `Host` header to cause the server to make requests to arbitrary external servers or internal IP addresses (SSRF).
+**Learning:** In Next.js App Router, API routes should never use `fetch` with URLs derived from the incoming request's `Host` header to invoke other local route handlers. The `Host` header is untrustworthy.
+**Prevention:** Instead of using `fetch` to make a loopback HTTP request, import the other route handler function (e.g., `POST` from `../url/route`) directly and invoke it as a normal asynchronous function call. Pass a synthetic `NextRequest` (e.g., `new NextRequest(new URL('http://localhost'), { method: 'POST', body: ... })`) to satisfy the handler's parameters.

--- a/src/app/api/lookup/bulk/route.test.ts
+++ b/src/app/api/lookup/bulk/route.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from './route';
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { POST as urlPOST } from '../url/route';
+import { POST as doiPOST } from '../doi/route';
+import { POST as isbnPOST } from '../isbn/route';
 
-global.fetch = vi.fn();
+vi.mock('../url/route', () => ({ POST: vi.fn() }));
+vi.mock('../doi/route', () => ({ POST: vi.fn() }));
+vi.mock('../isbn/route', () => ({ POST: vi.fn() }));
 
 function makeRequest(body: object) {
   return new NextRequest('http://localhost/api/lookup/bulk', {
@@ -54,47 +59,40 @@ describe('Bulk Lookup API', () => {
   });
 
   it('routes URLs to /api/lookup/url', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ data: { title: 'Example Page' } }),
-    });
+    (urlPOST as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      NextResponse.json({ data: { title: 'Example Page' } }, { status: 200 })
+    );
     const response = await POST(makeRequest({ items: ['https://example.com'] }));
     const data = await response.json();
     expect(data.results[0].success).toBe(true);
     expect(data.results[0].data.title).toBe('Example Page');
-    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
-    expect(url).toContain('/api/lookup/url');
+    expect(urlPOST).toHaveBeenCalled();
   });
 
   it('routes DOIs to /api/lookup/doi', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ data: { title: 'Research Article' } }),
-    });
+    (doiPOST as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      NextResponse.json({ data: { title: 'Research Article' } }, { status: 200 })
+    );
     const response = await POST(makeRequest({ items: ['10.1000/xyz123'] }));
     const data = await response.json();
     expect(data.results[0].success).toBe(true);
-    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
-    expect(url).toContain('/api/lookup/doi');
+    expect(doiPOST).toHaveBeenCalled();
   });
 
   it('routes ISBNs to /api/lookup/isbn', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ data: { title: 'Book Title' } }),
-    });
+    (isbnPOST as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      NextResponse.json({ data: { title: 'Book Title' } }, { status: 200 })
+    );
     const response = await POST(makeRequest({ items: ['9780316769174'] }));
     const data = await response.json();
     expect(data.results[0].success).toBe(true);
-    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
-    expect(url).toContain('/api/lookup/isbn');
+    expect(isbnPOST).toHaveBeenCalled();
   });
 
   it('marks item as failed when sub-request fails', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ error: 'Not found' }),
-    });
+    (doiPOST as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      NextResponse.json({ error: 'Not found' }, { status: 404 })
+    );
     const response = await POST(makeRequest({ items: ['10.1000/nonexistent'] }));
     const data = await response.json();
     expect(data.results[0].success).toBe(false);
@@ -102,9 +100,12 @@ describe('Bulk Lookup API', () => {
   });
 
   it('returns summary counts', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'A' } }) })
-      .mockResolvedValueOnce({ ok: false, json: async () => ({ error: 'fail' }) });
+    (urlPOST as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      NextResponse.json({ data: { title: 'A' } }, { status: 200 })
+    );
+    (doiPOST as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      NextResponse.json({ error: 'fail' }, { status: 400 })
+    );
     const response = await POST(
       makeRequest({ items: ['https://success.com', '10.1000/fail'] })
     );
@@ -115,9 +116,12 @@ describe('Bulk Lookup API', () => {
   });
 
   it('handles mixed item types in one batch', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'URL result' } }) })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'DOI result' } }) });
+    (urlPOST as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      NextResponse.json({ data: { title: 'URL result' } }, { status: 200 })
+    );
+    (doiPOST as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      NextResponse.json({ data: { title: 'DOI result' } }, { status: 200 })
+    );
     const response = await POST(
       makeRequest({ items: ['https://example.com', '10.1000/abc'] })
     );

--- a/src/app/api/lookup/bulk/route.ts
+++ b/src/app/api/lookup/bulk/route.ts
@@ -1,4 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { POST as urlPOST } from "../url/route";
+import { POST as doiPOST } from "../doi/route";
+import { POST as isbnPOST } from "../isbn/route";
 
 interface LookupResult {
   input: string;
@@ -22,7 +25,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Refactored to process lookups concurrently for performance improvement
-    const baseUrl = request.nextUrl.origin;
+    // Direct invocation prevents Host-header loopback SSRF
 
     const lookupPromises = items.map(async (item) => {
       const trimmedItem = item.trim();
@@ -31,18 +34,18 @@ export async function POST(request: NextRequest) {
       }
 
       try {
-        let apiEndpoint: string;
+        let handler: (req: NextRequest) => Promise<NextResponse>;
         let body: object;
 
         // Detect input type
         if (trimmedItem.match(/^(https?:\/\/|www\.)/i)) {
-          apiEndpoint = "/api/lookup/url";
+          handler = urlPOST;
           body = { url: trimmedItem };
         } else if (trimmedItem.match(/^10\.\d{4,}/)) {
-          apiEndpoint = "/api/lookup/doi";
+          handler = doiPOST;
           body = { doi: trimmedItem };
         } else if (trimmedItem.match(/^(97[89])?\d{9}[\dXx]$/)) {
-          apiEndpoint = "/api/lookup/isbn";
+          handler = isbnPOST;
           body = { isbn: trimmedItem };
         } else {
           return {
@@ -52,13 +55,14 @@ export async function POST(request: NextRequest) {
           };
         }
 
-        // Make the API call
-        const response = await fetch(`${baseUrl}${apiEndpoint}`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
+        // Create synthetic NextRequest to invoke the handler directly
+        const syntheticRequest = new NextRequest(new URL('http://localhost'), {
+          method: 'POST',
           body: JSON.stringify(body),
+          headers: { "Content-Type": "application/json" }
         });
 
+        const response = await handler(syntheticRequest);
         const data = await response.json();
 
         if (response.ok && data.data) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The bulk API endpoint (`src/app/api/lookup/bulk/route.ts`) was using `request.nextUrl.origin` to construct an absolute URL for a `fetch` call to other internal APIs. Because `request.nextUrl.origin` is derived from the HTTP `Host` header sent by the client, an attacker could spoof the `Host` header to cause the server to make requests to arbitrary external servers or internal IP addresses (SSRF).
🎯 Impact: This could be exploited to bypass security controls, interact with internal networks, or launch DoS attacks.
🔧 Fix: Instead of using `fetch` to make a loopback HTTP request, the code now imports the other route handler functions (e.g., `POST` from `../url/route`) directly and invokes them as normal asynchronous function calls. A synthetic `NextRequest` is passed to satisfy the handler's parameters.
✅ Verification: Ran `pnpm test:run` to ensure the bulk API works securely and passes all tests.

---
*PR created automatically by Jules for task [1604677428229134358](https://jules.google.com/task/1604677428229134358) started by @aicoder2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Server-Side Request Forgery (SSRF) vulnerability in the bulk API route that could be exploited through manipulated host headers.

* **Refactor**
  * Enhanced internal architecture of the bulk lookup API for improved reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->