### PR TITLE
⚡ Bolt: Derive project lists in-memory to avoid duplicate queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Concurrent Fetching with Owner IDs in Share Links
 **Learning:** In the share system, endpoints processing a share code typically suffer from waterfall latency by first loading target entity details (like a project) and then querying its associated elements (like project lists) using the entity's owner ID (`userId`). However, the `shareLink` object already contains the `userId` field (representing the owner's ID).
 **Action:** Always leverage the existing owner's ID within `shareLink` to bypass sequential dependencies and fetch parent entities (like projects) concurrently with their child elements (like user lists) using `Promise.all`.
+
+## 2024-05-19 - Derive Subsets In-Memory
+**Learning:** When fetching a global collection (e.g., all user lists) and a subset of that collection (e.g., lists for a specific project) simultaneously on the frontend, making two separate API calls is redundant and causes duplicate backend database queries.
+**Action:** Always derive the subset in-memory using array filtering (e.g., `allLists.filter(list => list.projectId === projectId)`) from the global collection instead of making a redundant API request.

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -60,15 +60,15 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       // OPTIMIZATION: Execute independent network requests and JSON parsing concurrently
       // using Promise.all. This prevents a 3-step waterfall, reducing Time to First Byte
       // (TTFB) and overall load time significantly on this detail page.
-      const [projectRes, listsRes, allListsRes] = await Promise.all([
+      // Furthermore, instead of fetching project lists separately, we derive them
+      // in-memory from the all-lists fetch to avoid duplicate backend queries.
+      const [projectRes, allListsRes] = await Promise.all([
         fetch(`/api/projects/${projectId}`),
-        fetch(`/api/projects/${projectId}/lists`),
         fetch("/api/lists"),
       ]);
 
-      const [projectResult, listsResult, allListsResult] = await Promise.all([
+      const [projectResult, allListsResult] = await Promise.all([
         projectRes.json(),
-        listsRes.json(),
         allListsRes.json(),
       ]);
 
@@ -81,12 +81,13 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setEditName(projectResult.data.name);
       setEditDescription(projectResult.data.description || "");
 
-      if (listsResult.success) {
-        setLists(listsResult.data);
-      }
-
       if (allListsResult.success) {
         setAllLists(allListsResult.data);
+        // Derive the project lists in-memory
+        const projectLists = allListsResult.data.filter(
+          (list: List) => list.projectId === projectId
+        );
+        setLists(projectLists);
       }
     } catch (err) {
       console.error("Error fetching project:", err);


### PR DESCRIPTION
💡 **What:** Replaced the redundant `/api/projects/[id]/lists` fetch in the `fetchProjectAndLists` function of `src/app/projects/[id]/page.tsx`. Instead of making a separate API call, we now filter the all-lists data (`allListsResult.data`) in-memory to derive the subset of lists that belong to the current project.

🎯 **Why:** The project detail page was fetching all lists and project-specific lists simultaneously, leading to unnecessary network traffic and duplicate database querying on the backend, creating performance bottlenecks.

📊 **Impact:** Reduces network requests on page load by 1 and cuts backend database querying in half for list fetching on this page, improving server load and potential TTFB slightly.

🔬 **Measurement:** You can verify this by observing the network tab in the browser or by running `pnpm test` and `pnpm lint` locally which both pass. Tests passed globally and I manually verified the logic.

---
*PR created automatically by Jules for task [2402460240466431541](https://jules.google.com/task/2402460240466431541) started by @aicoder2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development guidelines for data retrieval strategies.

* **Refactor**
  * Optimized project data loading by reducing the number of API calls required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->