### PR TITLE
⚡ Bolt: Derive project lists in-memory to reduce redundant API requests

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Concurrent Fetching with Owner IDs in Share Links
 **Learning:** In the share system, endpoints processing a share code typically suffer from waterfall latency by first loading target entity details (like a project) and then querying its associated elements (like project lists) using the entity's owner ID (`userId`). However, the `shareLink` object already contains the `userId` field (representing the owner's ID).
 **Action:** Always leverage the existing owner's ID within `shareLink` to bypass sequential dependencies and fetch parent entities (like projects) concurrently with their child elements (like user lists) using `Promise.all`.
+
+## 2024-06-08 - [In-Memory Filtering for Subsets]
+**Learning:** When fetching a global collection (e.g., all lists) and a subset of that collection (e.g., project lists) simultaneously on the frontend, making redundant API requests for the subset causes duplicate backend database queries and increases load times.
+**Action:** Always derive the subset in-memory using array filtering (e.g., `allLists.filter(list => list.projectId === projectId)`) from the globally fetched collection to avoid unnecessary network requests and database queries.

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -60,15 +60,14 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       // OPTIMIZATION: Execute independent network requests and JSON parsing concurrently
       // using Promise.all. This prevents a 3-step waterfall, reducing Time to First Byte
       // (TTFB) and overall load time significantly on this detail page.
-      const [projectRes, listsRes, allListsRes] = await Promise.all([
+      // Additionally, derive project lists in-memory from all lists instead of making a redundant API request.
+      const [projectRes, allListsRes] = await Promise.all([
         fetch(`/api/projects/${projectId}`),
-        fetch(`/api/projects/${projectId}/lists`),
         fetch("/api/lists"),
       ]);
 
-      const [projectResult, listsResult, allListsResult] = await Promise.all([
+      const [projectResult, allListsResult] = await Promise.all([
         projectRes.json(),
-        listsRes.json(),
         allListsRes.json(),
       ]);
 
@@ -81,12 +80,10 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setEditName(projectResult.data.name);
       setEditDescription(projectResult.data.description || "");
 
-      if (listsResult.success) {
-        setLists(listsResult.data);
-      }
-
       if (allListsResult.success) {
-        setAllLists(allListsResult.data);
+        const allListsData = allListsResult.data as List[];
+        setAllLists(allListsData);
+        setLists(allListsData.filter((list) => list.projectId === projectId));
       }
     } catch (err) {
       console.error("Error fetching project:", err);


### PR DESCRIPTION
💡 **What**: Removed the redundant fetch for `/api/projects/${projectId}/lists` on the project details page and derived the data in-memory by filtering the result of `/api/lists`.

🎯 **Why**: When a user visits a project page, the application was making an API call for a specific project's lists and another API call for ALL lists concurrently. This caused duplicate database queries on the backend since the DynamoDB implementation of `getProjectLists` already fetches all user lists and filters them.

📊 **Impact**: Reduces backend database queries by half (for lists) and eliminates one full network round-trip from the client, noticeably improving Time to First Byte (TTFB).

🔬 **Measurement**: Inspect the Network tab on `/projects/[id]`. You will no longer see the `/api/projects/[id]/lists` request firing. The UI should populate identical list data just as fast or faster.

---
*PR created automatically by Jules for task [1241041028634973475](https://jules.google.com/task/1241041028634973475) started by @aicoder2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined project list retrieval by optimizing data fetching and processing, reducing unnecessary network requests and significantly improving page load times.

* **Chores**
  * Added development documentation with guidance on efficient in-memory data filtering approaches for similar use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->