### PR TITLE
🛡️ Sentinel: [HIGH] Fix Host-header SSRF in bulk lookup API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The application was using the `marked` library to parse Markdown content into HTML (in `src/app/docs/changelog/page.tsx` and `src/lib/docs.ts`) and subsequently rendering it using `dangerouslySetInnerHTML` without proper sanitization.
 **Learning:** `marked` does not sanitize HTML by default. While this may seem safe for trusted inputs (like internal docs or GitHub releases), if malicious input manages to enter these sources, it leads directly to an XSS vulnerability.
 **Prevention:** The output of `marked` (or any markdown parser) must always be wrapped with `DOMPurify.sanitize()` (using `isomorphic-dompurify` for SSR) before being passed to `dangerouslySetInnerHTML`.
+## 2025-02-28 - [Host-header SSRF in Loopback Fetch]
+**Vulnerability:** The `src/app/api/lookup/bulk/route.ts` API endpoint performed loopback `fetch` requests (e.g., to `/api/lookup/url`) using a dynamically derived hostname (`request.nextUrl.origin`). This exposed the application to Host-header Server-Side Request Forgery (SSRF) because an attacker could manipulate the `Host` header to route the internal request to an arbitrary server.
+**Learning:** Depending on the `Host` header to construct absolute URLs for internal API calls creates an SSRF risk, as the user controls the `Host` header.
+**Prevention:** Instead of performing a loopback HTTP `fetch`, internal route handlers (like `POST` methods) should be imported and invoked directly using a synthetic `NextRequest` (e.g., `new NextRequest(new URL('http://localhost'), ...)`).

--- a/src/app/api/lookup/bulk/route.test.ts
+++ b/src/app/api/lookup/bulk/route.test.ts
@@ -1,8 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from './route';
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { POST as urlPost } from '../url/route';
+import { POST as doiPost } from '../doi/route';
+import { POST as isbnPost } from '../isbn/route';
 
-global.fetch = vi.fn();
+vi.mock('../url/route', () => ({
+  POST: vi.fn(),
+}));
+
+vi.mock('../doi/route', () => ({
+  POST: vi.fn(),
+}));
+
+vi.mock('../isbn/route', () => ({
+  POST: vi.fn(),
+}));
 
 function makeRequest(body: object) {
   return new NextRequest('http://localhost/api/lookup/bulk', {
@@ -54,47 +67,40 @@ describe('Bulk Lookup API', () => {
   });
 
   it('routes URLs to /api/lookup/url', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ data: { title: 'Example Page' } }),
-    });
+    (urlPost as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      NextResponse.json({ data: { title: 'Example Page' } }, { status: 200 })
+    );
     const response = await POST(makeRequest({ items: ['https://example.com'] }));
     const data = await response.json();
     expect(data.results[0].success).toBe(true);
     expect(data.results[0].data.title).toBe('Example Page');
-    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
-    expect(url).toContain('/api/lookup/url');
+    expect(urlPost).toHaveBeenCalled();
   });
 
   it('routes DOIs to /api/lookup/doi', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ data: { title: 'Research Article' } }),
-    });
+    (doiPost as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      NextResponse.json({ data: { title: 'Research Article' } }, { status: 200 })
+    );
     const response = await POST(makeRequest({ items: ['10.1000/xyz123'] }));
     const data = await response.json();
     expect(data.results[0].success).toBe(true);
-    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
-    expect(url).toContain('/api/lookup/doi');
+    expect(doiPost).toHaveBeenCalled();
   });
 
   it('routes ISBNs to /api/lookup/isbn', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ data: { title: 'Book Title' } }),
-    });
+    (isbnPost as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      NextResponse.json({ data: { title: 'Book Title' } }, { status: 200 })
+    );
     const response = await POST(makeRequest({ items: ['9780316769174'] }));
     const data = await response.json();
     expect(data.results[0].success).toBe(true);
-    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
-    expect(url).toContain('/api/lookup/isbn');
+    expect(isbnPost).toHaveBeenCalled();
   });
 
   it('marks item as failed when sub-request fails', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ error: 'Not found' }),
-    });
+    (doiPost as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      NextResponse.json({ error: 'Not found' }, { status: 404 })
+    );
     const response = await POST(makeRequest({ items: ['10.1000/nonexistent'] }));
     const data = await response.json();
     expect(data.results[0].success).toBe(false);
@@ -102,9 +108,12 @@ describe('Bulk Lookup API', () => {
   });
 
   it('returns summary counts', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'A' } }) })
-      .mockResolvedValueOnce({ ok: false, json: async () => ({ error: 'fail' }) });
+    (urlPost as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      NextResponse.json({ data: { title: 'A' } }, { status: 200 })
+    );
+    (doiPost as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      NextResponse.json({ error: 'fail' }, { status: 500 })
+    );
     const response = await POST(
       makeRequest({ items: ['https://success.com', '10.1000/fail'] })
     );
@@ -115,9 +124,12 @@ describe('Bulk Lookup API', () => {
   });
 
   it('handles mixed item types in one batch', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'URL result' } }) })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'DOI result' } }) });
+    (urlPost as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      NextResponse.json({ data: { title: 'URL result' } }, { status: 200 })
+    );
+    (doiPost as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      NextResponse.json({ data: { title: 'DOI result' } }, { status: 200 })
+    );
     const response = await POST(
       makeRequest({ items: ['https://example.com', '10.1000/abc'] })
     );

--- a/src/app/api/lookup/bulk/route.ts
+++ b/src/app/api/lookup/bulk/route.ts
@@ -1,4 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { POST as urlPost } from "../url/route";
+import { POST as doiPost } from "../doi/route";
+import { POST as isbnPost } from "../isbn/route";
 
 interface LookupResult {
   input: string;
@@ -22,8 +25,6 @@ export async function POST(request: NextRequest) {
     }
 
     // Refactored to process lookups concurrently for performance improvement
-    const baseUrl = request.nextUrl.origin;
-
     const lookupPromises = items.map(async (item) => {
       const trimmedItem = item.trim();
       if (!trimmedItem) {
@@ -31,18 +32,18 @@ export async function POST(request: NextRequest) {
       }
 
       try {
-        let apiEndpoint: string;
+        let handler: (req: NextRequest) => Promise<NextResponse>;
         let body: object;
 
         // Detect input type
         if (trimmedItem.match(/^(https?:\/\/|www\.)/i)) {
-          apiEndpoint = "/api/lookup/url";
+          handler = urlPost;
           body = { url: trimmedItem };
         } else if (trimmedItem.match(/^10\.\d{4,}/)) {
-          apiEndpoint = "/api/lookup/doi";
+          handler = doiPost;
           body = { doi: trimmedItem };
         } else if (trimmedItem.match(/^(97[89])?\d{9}[\dXx]$/)) {
-          apiEndpoint = "/api/lookup/isbn";
+          handler = isbnPost;
           body = { isbn: trimmedItem };
         } else {
           return {
@@ -52,13 +53,14 @@ export async function POST(request: NextRequest) {
           };
         }
 
-        // Make the API call
-        const response = await fetch(`${baseUrl}${apiEndpoint}`, {
-          method: "POST",
+        // Invoke the internal route handler directly using a synthetic NextRequest
+        const syntheticRequest = new NextRequest(new URL('http://localhost'), {
+          method: 'POST',
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(body),
+          body: JSON.stringify(body)
         });
 
+        const response = await handler(syntheticRequest);
         const data = await response.json();
 
         if (response.ok && data.data) {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `/api/lookup/bulk/route.ts` endpoint performed internal API loopback HTTP `fetch` requests constructed using a dynamically derived hostname (`request.nextUrl.origin`). This relies on the HTTP `Host` header, which is user-controllable. An attacker could manipulate this header to route the internal lookup requests to an arbitrary internal IP or domain (Host-header Server-Side Request Forgery).
🎯 **Impact:** An attacker could potentially bypass SSRF protections, access restricted internal network endpoints, or perform cache poisoning depending on the environment architecture.
🔧 **Fix:** Refactored the endpoint to avoid loopback `fetch` calls entirely. Internal route handlers (`urlPost`, `doiPost`, `isbnPost`) are now directly imported and invoked using a synthetic `NextRequest` object (`new NextRequest(new URL('http://localhost'), ...)`). This avoids DNS/network boundaries, effectively neutralizing the SSRF vector while simultaneously improving latency.
✅ **Verification:** Unit tests for `/api/lookup/bulk/route.test.ts` have been updated to mock the local route files instead of `global.fetch` and pass successfully (`pnpm test`).

---
*PR created automatically by Jules for task [10779170663556295043](https://jules.google.com/task/10779170663556295043) started by @aicoder2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a host-header SSRF vulnerability in the bulk lookup API.

* **Tests**
  * Updated bulk lookup test suite to verify correct routing behavior.

* **Documentation**
  * Documented security finding related to bulk lookup API request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->