### PR TITLE
feat: command palette (⌘K), RIS import, settings page, global search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ npm run dev             # Next dev server
 npm run build           # Production build
 npm run lint            # ESLint
 npm run test            # Vitest (watch mode)
-npm run test:run        # Vitest (single run, 668 tests)
+npm run test:run        # Vitest (single run, 695 tests)
 npm run electron:dev    # Electron + Next dev together
 npm run electron:build  # Package desktop app (mac/win/linux variants available)
 ```
@@ -26,7 +26,7 @@ npm run electron:build  # Package desktop app (mac/win/linux variants available)
 - **Desktop:** Electron 34 (wraps the same Next app)
 - **PWA:** Service worker + offline store + sync manager
 - **DnD:** `@dnd-kit` for reorderable citations
-- **Testing:** Vitest + Testing Library (668 tests)
+- **Testing:** Vitest + Testing Library (695 tests)
 
 ## Architecture
 
@@ -35,6 +35,7 @@ npm run electron:build  # Package desktop app (mac/win/linux variants available)
 - **Source types (11):** Book, Journal, Website, Blog, Newspaper, Video, Image, Film, TV Series, TV Episode, Miscellaneous
 - **Access types (5):** Print, Database, Web, App, Archive
 - **Exporters:** BibTeX (`.bib`), RIS (`.ris`), plain `.txt`
+- **Importers:** BibTeX and RIS (`src/lib/citation/importers/`) — the cite page's Import tab auto-detects the format
 - Both full citations and in-text citations are formatted here (`generateInTextCitation`)
 
 ### API Routes (`src/app/api/`)
@@ -49,6 +50,7 @@ npm run electron:build  # Package desktop app (mac/win/linux variants available)
 | `/api/lookup/bulk` | Batch lookup |
 | `/api/lists/` | Lists CRUD (+ nested citations) |
 | `/api/projects/` | Projects CRUD (+ nested lists) |
+| `/api/search/` | Search the user's projects, lists, citations (`/search` page) |
 | `/api/share/` | Public share links (`/share/[code]`) |
 | `/api/badge/` | Embeddable badge image |
 | `/api/stats/` | Public usage stats (+ `/stats/increment`) |
@@ -71,6 +73,8 @@ src/
 │   ├── cite/               # Citation generator
 │   ├── lists/              # Lists management
 │   ├── projects/           # Projects management
+│   ├── search/             # Global search across lists/projects/citations
+│   ├── settings/           # Device-local preferences (defaults, theme)
 │   ├── share/[code]/       # Public share pages
 │   ├── embed/              # Embeddable citation widget
 │   ├── home/               # Marketing / landing
@@ -81,9 +85,12 @@ src/
 │   ├── pwa/                # PWA provider, offline indicator, Safari install banner
 │   └── retro/              # Retro ASCII print animation
 ├── lib/
-│   ├── citation/           # Formatters + exporters
+│   ├── citation/           # Formatters + exporters + importers
 │   ├── db/                 # DynamoDB client, queries, offline store
 │   ├── pwa/                # Service worker utils, offline store, sync manager
+│   ├── citation-options.ts # Shared source/style/access option lists (cite + settings pages)
+│   ├── preferences.ts      # localStorage user preferences (default style, etc.)
+│   ├── fuzzy-match.ts      # Fuzzy matcher behind the ⌘K command palette
 │   ├── templates.ts        # Citation templates (prefilled fields)
 │   └── keyboard-shortcuts.ts
 └── types/                  # TypeScript definitions
@@ -101,12 +108,12 @@ Early-mid 2000s Wikipedia aesthetic: clean, information-dense, utilitarian. Gene
 1. Create formatter in `src/lib/citation/formatters/<style>.ts`
 2. Register it in `src/lib/citation/index.ts` (`formatCitation` switch + `getFormatter`) and add an in-text branch in `generateInTextCitation`
 3. Add tests in `<style>.test.ts`
-4. Add to `CITATION_STYLES` in `src/app/cite/page.tsx`
+4. Add to `CITATION_STYLES` in `src/lib/citation-options.ts`
 
 ### Adding a Source Type
-1. Add to `src/types/source-types.ts`
+1. Add to `src/types/source-types.ts` and `SOURCE_TYPES` in `src/lib/citation-options.ts`
 2. Add form fields in `src/app/cite/page.tsx` (`renderSourceFields`)
-3. Handle in all 4 formatters + exporters (BibTeX, RIS)
+3. Handle in all 4 formatters + exporters and importers (BibTeX, RIS)
 4. Add tests
 
 ### Adding a Lookup Provider

--- a/src/app/api/search/route.test.ts
+++ b/src/app/api/search/route.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET } from "./route";
+import { NextRequest } from "next/server";
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getUserLists: vi.fn(),
+  getUserProjects: vi.fn(),
+  getListCitations: vi.fn(),
+}));
+
+import { auth } from "@clerk/nextjs/server";
+import { getUserLists, getUserProjects, getListCitations } from "@/lib/db";
+
+const mockAuth = auth as unknown as ReturnType<typeof vi.fn>;
+const mockGetUserLists = getUserLists as unknown as ReturnType<typeof vi.fn>;
+const mockGetUserProjects = getUserProjects as unknown as ReturnType<typeof vi.fn>;
+const mockGetListCitations = getListCitations as unknown as ReturnType<typeof vi.fn>;
+
+function makeRequest(q?: string) {
+  const url = q !== undefined
+    ? `http://localhost/api/search?q=${encodeURIComponent(q)}`
+    : "http://localhost/api/search";
+  return new NextRequest(url);
+}
+
+const LISTS = [
+  { id: "list-1", name: "Climate Research", userId: "user-123", createdAt: "2024-01-01", updatedAt: "2024-01-01" },
+  { id: "list-2", name: "History Essay", description: "Sources on climate treaties", userId: "user-123", createdAt: "2024-01-02", updatedAt: "2024-01-02" },
+];
+
+const PROJECTS = [
+  { id: "project-1", name: "Thesis", description: "Climate change chapter", userId: "user-123", createdAt: "2024-01-01", updatedAt: "2024-01-01" },
+];
+
+const CITATIONS_LIST_1 = [
+  {
+    id: "cit-1",
+    listId: "list-1",
+    fields: { sourceType: "journal", accessType: "web", title: "Warming Trends", authors: [{ lastName: "Hansen", firstName: "James" }], journalTitle: "Science" },
+    style: "apa",
+    formattedText: "Hansen, J. (2023). Warming Trends. Science.",
+    formattedHtml: "",
+    tags: ["climate"],
+    createdAt: "2024-01-01",
+    updatedAt: "2024-01-01",
+  },
+  {
+    id: "cit-2",
+    listId: "list-1",
+    fields: { sourceType: "book", accessType: "print", title: "Unrelated Book" },
+    style: "apa",
+    formattedText: "Unrelated Book.",
+    formattedHtml: "",
+    createdAt: "2024-01-01",
+    updatedAt: "2024-01-01",
+  },
+];
+
+describe("Search API - /api/search", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 if not authenticated", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+
+    const response = await GET(makeRequest("climate"));
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.success).toBe(false);
+  });
+
+  it("returns 400 for queries shorter than 2 characters", async () => {
+    mockAuth.mockResolvedValue({ userId: "user-123" });
+
+    for (const q of [undefined, "", "a", " x "]) {
+      const response = await GET(makeRequest(q));
+      expect(response.status).toBe(400);
+    }
+  });
+
+  it("matches projects, lists, and citations case-insensitively", async () => {
+    mockAuth.mockResolvedValue({ userId: "user-123" });
+    mockGetUserLists.mockResolvedValue(LISTS);
+    mockGetUserProjects.mockResolvedValue(PROJECTS);
+    mockGetListCitations.mockImplementation((listId: string) =>
+      Promise.resolve(listId === "list-1" ? CITATIONS_LIST_1 : [])
+    );
+
+    const response = await GET(makeRequest("CLIMATE"));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    // "Climate" in project description, list-1 name, list-2 description.
+    expect(data.data.projects.map((p: { id: string }) => p.id)).toEqual(["project-1"]);
+    expect(data.data.lists.map((l: { id: string }) => l.id)).toEqual(["list-1", "list-2"]);
+    // cit-1 matches via tag "climate"; cit-2 doesn't match.
+    expect(data.data.citations).toHaveLength(1);
+    expect(data.data.citations[0]).toMatchObject({
+      id: "cit-1",
+      listId: "list-1",
+      listName: "Climate Research",
+      title: "Warming Trends",
+    });
+  });
+
+  it("matches citations by author name", async () => {
+    mockAuth.mockResolvedValue({ userId: "user-123" });
+    mockGetUserLists.mockResolvedValue(LISTS);
+    mockGetUserProjects.mockResolvedValue([]);
+    mockGetListCitations.mockImplementation((listId: string) =>
+      Promise.resolve(listId === "list-1" ? CITATIONS_LIST_1 : [])
+    );
+
+    const response = await GET(makeRequest("hansen"));
+    const data = await response.json();
+
+    expect(data.data.citations).toHaveLength(1);
+    expect(data.data.citations[0].id).toBe("cit-1");
+    expect(data.data.projects).toEqual([]);
+    expect(data.data.lists).toEqual([]);
+  });
+
+  it("returns empty groups when nothing matches", async () => {
+    mockAuth.mockResolvedValue({ userId: "user-123" });
+    mockGetUserLists.mockResolvedValue(LISTS);
+    mockGetUserProjects.mockResolvedValue(PROJECTS);
+    mockGetListCitations.mockResolvedValue([]);
+
+    const response = await GET(makeRequest("zzzz"));
+    const data = await response.json();
+
+    expect(data.data.projects).toEqual([]);
+    expect(data.data.lists).toEqual([]);
+    expect(data.data.citations).toEqual([]);
+  });
+
+  it("handles database errors gracefully", async () => {
+    mockAuth.mockResolvedValue({ userId: "user-123" });
+    mockGetUserLists.mockRejectedValue(new Error("boom"));
+    mockGetUserProjects.mockResolvedValue([]);
+
+    const response = await GET(makeRequest("climate"));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.success).toBe(false);
+  });
+});

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { getUserLists, getUserProjects, getListCitations, type Citation, type List } from "@/lib/db";
+
+const MAX_CITATION_RESULTS = 50;
+
+function matches(query: string, ...haystacks: Array<string | undefined>): boolean {
+  return haystacks.some((h) => h?.toLowerCase().includes(query));
+}
+
+function citationMatches(query: string, citation: Citation): boolean {
+  const { fields } = citation;
+  return (
+    matches(query, fields.title, fields.subtitle, citation.formattedText, citation.notes) ||
+    (citation.tags ?? []).some((tag) => tag.toLowerCase().includes(query)) ||
+    (fields.authors ?? []).some((a) =>
+      matches(query, a.lastName, a.firstName)
+    )
+  );
+}
+
+// GET /api/search?q= - Search the user's projects, lists, and citations
+export async function GET(request: NextRequest) {
+  try {
+    const { userId } = await auth();
+
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    const q = (request.nextUrl.searchParams.get("q") ?? "").trim().toLowerCase();
+    if (q.length < 2) {
+      return NextResponse.json(
+        { success: false, error: "Query must be at least 2 characters" },
+        { status: 400 }
+      );
+    }
+
+    const [lists, projects] = await Promise.all([
+      getUserLists(userId),
+      getUserProjects(userId),
+    ]);
+
+    const matchedProjects = projects
+      .filter((p) => matches(q, p.name, p.description))
+      .map((p) => ({ id: p.id, name: p.name, description: p.description }));
+
+    const matchedLists = lists
+      .filter((l) => matches(q, l.name, l.description))
+      .map((l) => ({ id: l.id, name: l.name, description: l.description }));
+
+    const perList = await Promise.all(
+      lists.map(async (list: List) => {
+        const citations = await getListCitations(list.id);
+        return citations
+          .filter((c) => citationMatches(q, c))
+          .map((c) => ({
+            id: c.id,
+            listId: list.id,
+            listName: list.name,
+            title: c.fields.title,
+            formattedText: c.formattedText,
+            tags: c.tags,
+          }));
+      })
+    );
+
+    const matchedCitations = perList.flat().slice(0, MAX_CITATION_RESULTS);
+
+    return NextResponse.json(
+      {
+        success: true,
+        data: {
+          query: q,
+          projects: matchedProjects,
+          lists: matchedLists,
+          citations: matchedCitations,
+        },
+      },
+      { headers: { "Cache-Control": "private, no-cache" } }
+    );
+  } catch (error) {
+    console.error("Error searching:", error);
+    return NextResponse.json(
+      { success: false, error: "Search failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/cite/page.tsx
+++ b/src/app/cite/page.tsx
@@ -21,53 +21,18 @@ import { buildCitationFields } from "@/lib/citation/build-fields";
 import { saveTemplate, suggestTemplateName, type CitationTemplate } from "@/lib/templates";
 import { toBibTeX, toRIS, toRTF } from "@/lib/citation/exporters";
 import { parseAllBibTeX, type BibTeXParseResult } from "@/lib/citation/importers/bibtex";
+import { parseAllRIS, looksLikeRIS } from "@/lib/citation/importers/ris";
 import { recordCitationSave } from "@/lib/barnstar";
+import { SOURCE_TYPES, CITATION_STYLES, ACCESS_TYPES } from "@/lib/citation-options";
+import { getPreferences } from "@/lib/preferences";
 import DOMPurify from "isomorphic-dompurify";
-import type { CitationStyle, SourceType, AccessType, CitationFields } from "@/types";
+import type { SourceType, AccessType, CitationFields } from "@/types";
 import posthog from "posthog-js";
 
 interface List {
   id: string;
   name: string;
 }
-
-const SOURCE_TYPES: { value: SourceType; label: string }[] = [
-  { value: "book", label: "Book" },
-  { value: "book-chapter", label: "Book Chapter" },
-  { value: "journal", label: "Journal" },
-  { value: "website", label: "Website" },
-  { value: "blog", label: "Blog" },
-  { value: "newspaper", label: "Newspaper" },
-  { value: "video", label: "Video" },
-  { value: "image", label: "Image" },
-  { value: "film", label: "Film" },
-  { value: "tv-series", label: "TV Series" },
-  { value: "tv-episode", label: "TV Episode" },
-  { value: "song", label: "Song" },
-  { value: "album", label: "Album" },
-  { value: "podcast-episode", label: "Podcast Episode" },
-  { value: "video-game", label: "Video Game" },
-  { value: "artwork", label: "Artwork" },
-  { value: "thesis", label: "Thesis / Dissertation" },
-  { value: "conference-paper", label: "Conference Paper" },
-  { value: "dataset", label: "Dataset" },
-  { value: "software", label: "Software / Code" },
-  { value: "preprint", label: "Preprint" },
-  { value: "social-media", label: "Social Media" },
-  { value: "ai-generated", label: "AI-Generated" },
-  { value: "interview", label: "Interview" },
-  { value: "government-report", label: "Government Report" },
-  { value: "legal-case", label: "Legal Case" },
-  { value: "encyclopedia", label: "Encyclopedia" },
-  { value: "miscellaneous", label: "Miscellaneous" },
-];
-
-const CITATION_STYLES: { value: CitationStyle; label: string }[] = [
-  { value: "apa", label: "APA 7th" },
-  { value: "mla", label: "MLA 9th" },
-  { value: "chicago", label: "Chicago 17th" },
-  { value: "harvard", label: "Harvard" },
-];
 
 const NORMALIZE_REGEX = /\s+/g;
 const normalizeText = (text: string) => text.toLowerCase().replace(NORMALIZE_REGEX, " ").trim();
@@ -134,14 +99,6 @@ function researchTypeHelp(rt: ResearchType): string {
       return "Fetches article metadata from Wikipedia.";
   }
 }
-
-const ACCESS_TYPES: { value: AccessType; label: string }[] = [
-  { value: "web", label: "Web" },
-  { value: "print", label: "Print" },
-  { value: "database", label: "Database" },
-  { value: "app", label: "App" },
-  { value: "archive", label: "Archive" },
-];
 
 const STYLE_LABELS: Record<string, string> = {
   ...Object.fromEntries(CITATION_STYLES.map((s) => [s.value, s.label])),
@@ -398,6 +355,21 @@ function CitePageContent() {
   const [isResearchLoading, setIsResearchLoading] = useState(false);
   const [researchError, setResearchError] = useState<string | null>(null);
 
+  // Apply saved preferences once on mount. URL query params (handled in the
+  // effect below, which runs after this one) take precedence.
+  useEffect(() => {
+    const prefs = getPreferences();
+    if (STYLE_LABELS[prefs.defaultStyle]) {
+      setSelectedStyle(prefs.defaultStyle);
+    }
+    if (SOURCE_TYPES.some((s) => s.value === prefs.defaultSourceType)) {
+      setSelectedSourceType(prefs.defaultSourceType);
+    }
+    if (ACCESS_TYPES.some((a) => a.value === prefs.defaultAccessType)) {
+      setSelectedAccessType(prefs.defaultAccessType);
+    }
+  }, []);
+
   // Handle URL query parameters
   useEffect(() => {
     const inputParam = searchParams.get("input");
@@ -585,15 +557,17 @@ function CitePageContent() {
     setBibtexError(null);
     setBibtexResults([]);
     if (!bibtexInput.trim()) {
-      setBibtexError("Paste or upload a BibTeX entry first.");
+      setBibtexError("Paste or upload a BibTeX or RIS entry first.");
       return;
     }
 
     setIsBibtexLoading(true);
     try {
-      const entries = parseAllBibTeX(bibtexInput);
+      const entries = looksLikeRIS(bibtexInput)
+        ? parseAllRIS(bibtexInput)
+        : parseAllBibTeX(bibtexInput);
       if (entries.length === 0) {
-        setBibtexError("Could not parse any BibTeX entries. Check the syntax.");
+        setBibtexError("Could not parse any BibTeX or RIS entries. Check the syntax.");
         return;
       }
       if (entries.length === 1) {
@@ -603,7 +577,7 @@ function CitePageContent() {
       }
     } catch (err) {
       console.error(err);
-      setBibtexError("Failed to parse BibTeX.");
+      setBibtexError("Failed to parse the pasted entries.");
     } finally {
       setIsBibtexLoading(false);
     }
@@ -2189,7 +2163,7 @@ function CitePageContent() {
           tabs={[
             { id: "quick-add", label: "Quick Add", active: activeTab === "quick-add" },
             { id: "research-lookup", label: "Research Lookup", active: activeTab === "research-lookup" },
-            { id: "paste-bibtex", label: "Import BibTeX", active: activeTab === "paste-bibtex" },
+            { id: "paste-bibtex", label: "Import BibTeX / RIS", active: activeTab === "paste-bibtex" },
             { id: "manual", label: "Manual Entry", active: activeTab === "manual" },
             { id: "bulk-import", label: "Bulk Import", active: activeTab === "bulk-import" },
           ]}
@@ -2331,31 +2305,31 @@ function CitePageContent() {
           )}
           </div>
 
-          <div role="tabpanel" id="tabpanel-paste-bibtex" aria-label="Import BibTeX" hidden={activeTab !== "paste-bibtex"}>
+          <div role="tabpanel" id="tabpanel-paste-bibtex" aria-label="Import BibTeX / RIS" hidden={activeTab !== "paste-bibtex"}>
           {activeTab === "paste-bibtex" && (
             <div>
-              <h2 className="text-lg font-semibold mb-4">Import BibTeX</h2>
+              <h2 className="text-lg font-semibold mb-4">Import BibTeX or RIS</h2>
               <p className="mb-4 text-sm text-wiki-text-muted">
-                Paste a BibTeX entry or upload a <code>.bib</code> file (e.g. from Google Scholar, Zotero, or the ACL Anthology). We detect source types, parse authors, editors, pages, and more.
+                Paste BibTeX or RIS entries, or upload a <code>.bib</code> / <code>.ris</code> file (e.g. from Google Scholar, Zotero, EndNote, or Mendeley). The format is detected automatically; we parse source types, authors, editors, pages, and more.
               </p>
 
               <div className="space-y-4">
                 <div>
                   <div className="flex items-center justify-between mb-2">
                     <label htmlFor="bibtex-input" className="block text-sm font-medium">
-                      BibTeX
+                      BibTeX or RIS
                     </label>
                     <WikiButton
                       onClick={() => bibtexFileInputRef.current?.click()}
                       className="text-xs"
                     >
-                      Upload .bib file
+                      Upload .bib / .ris file
                     </WikiButton>
                   </div>
                   <input
                     ref={bibtexFileInputRef}
                     type="file"
-                    accept=".bib,.bibtex,text/plain"
+                    accept=".bib,.bibtex,.ris,text/plain"
                     className="hidden"
                     onChange={handleBibtexFileUpload}
                   />
@@ -2366,7 +2340,7 @@ function CitePageContent() {
                       setBibtexInput(e.target.value);
                       setBibtexResults([]);
                     }}
-                    placeholder={`@inproceedings{smith2024,\n  title = {Example Title},\n  author = {Smith, Jane A. and Doe, John},\n  booktitle = {Proceedings of X},\n  year = {2024},\n  pages = {1--10}\n}`}
+                    placeholder={`@inproceedings{smith2024,\n  title = {Example Title},\n  author = {Smith, Jane A. and Doe, John},\n  booktitle = {Proceedings of X},\n  year = {2024},\n  pages = {1--10}\n}\n\nor\n\nTY  - JOUR\nAU  - Smith, Jane A.\nTI  - Example Title\nPY  - 2024\nER  -`}
                     rows={12}
                     className="w-full font-mono text-sm"
                   />

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useState, useEffect, useRef, Suspense } from "react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useUser } from "@clerk/nextjs";
+import { WikiLayout } from "@/components/wiki/wiki-layout";
+import { WikiBreadcrumbs } from "@/components/wiki/wiki-breadcrumbs";
+import { WikiSpinner } from "@/components/wiki/wiki-spinner";
+import { WikiNotice } from "@/components/wiki/wiki-notice";
+
+interface SearchResults {
+  query: string;
+  projects: Array<{ id: string; name: string; description?: string }>;
+  lists: Array<{ id: string; name: string; description?: string }>;
+  citations: Array<{
+    id: string;
+    listId: string;
+    listName: string;
+    title: string;
+    formattedText: string;
+    tags?: string[];
+  }>;
+}
+
+const DEBOUNCE_MS = 300;
+
+function SearchPageContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { isLoaded, isSignedIn } = useUser();
+  const [query, setQuery] = useState(searchParams.get("q") ?? "");
+  const [results, setResults] = useState<SearchResults | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    if (isLoaded && !isSignedIn) {
+      router.push("/sign-in?redirect_url=/search");
+    }
+  }, [isLoaded, isSignedIn, router]);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    const requestId = ++requestIdRef.current;
+
+    // Keep the URL shareable/bookmarkable.
+    const url = trimmed ? `/search?q=${encodeURIComponent(trimmed)}` : "/search";
+    window.history.replaceState(null, "", url);
+
+    if (trimmed.length < 2) {
+      setResults(null);
+      setIsSearching(false);
+      return;
+    }
+
+    setIsSearching(true);
+    const timer = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/search?q=${encodeURIComponent(trimmed)}`);
+        const data = await res.json();
+        if (requestId !== requestIdRef.current) return; // stale response
+        if (data.success) {
+          setResults(data.data);
+          setError(null);
+        } else {
+          setError(data.error || "Search failed");
+        }
+      } catch {
+        if (requestId === requestIdRef.current) setError("Search failed");
+      } finally {
+        if (requestId === requestIdRef.current) setIsSearching(false);
+      }
+    }, DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  if (!isLoaded || (isLoaded && !isSignedIn)) {
+    return (
+      <WikiLayout>
+        <WikiSpinner />
+      </WikiLayout>
+    );
+  }
+
+  const totalResults = results
+    ? results.projects.length + results.lists.length + results.citations.length
+    : 0;
+
+  return (
+    <WikiLayout>
+      <WikiBreadcrumbs
+        items={[{ label: "Home", href: "/" }, { label: "Search" }]}
+      />
+
+      <div className="mt-6">
+        <div className="border border-wiki-border-light bg-wiki-white p-6 md:p-8">
+          <h1 className="text-2xl font-bold mb-1">Search</h1>
+          <p className="text-wiki-text-muted text-sm mb-6">
+            Search across all your projects, lists, and citations.
+          </p>
+
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search by title, author, tag, note..."
+            className="w-full"
+            aria-label="Search your projects, lists, and citations"
+            autoFocus
+          />
+
+          {error && (
+            <div className="mt-4">
+              <WikiNotice variant="warn" onDismiss={() => setError(null)}>{error}</WikiNotice>
+            </div>
+          )}
+
+          <div className="mt-6" role="status" aria-live="polite">
+            {query.trim().length < 2 ? (
+              <p className="text-sm text-wiki-text-muted">
+                Type at least two characters to search.
+              </p>
+            ) : isSearching ? (
+              <WikiSpinner />
+            ) : results && totalResults === 0 ? (
+              <p className="text-sm text-wiki-text-muted">
+                No results for &ldquo;{results.query}&rdquo;.
+              </p>
+            ) : results ? (
+              <div className="space-y-8">
+                {results.projects.length > 0 && (
+                  <section>
+                    <h2 className="text-lg font-semibold mb-2">
+                      Projects ({results.projects.length})
+                    </h2>
+                    <ul className="divide-y divide-wiki-border-light border border-wiki-border-light">
+                      {results.projects.map((project) => (
+                        <li key={project.id} className="px-3 py-2">
+                          <Link
+                            href={`/projects/${project.id}`}
+                            className="text-wiki-link hover:underline font-medium focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
+                          >
+                            {project.name}
+                          </Link>
+                          {project.description && (
+                            <p className="text-xs text-wiki-text-muted mt-0.5 line-clamp-2">
+                              {project.description}
+                            </p>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                )}
+
+                {results.lists.length > 0 && (
+                  <section>
+                    <h2 className="text-lg font-semibold mb-2">
+                      Lists ({results.lists.length})
+                    </h2>
+                    <ul className="divide-y divide-wiki-border-light border border-wiki-border-light">
+                      {results.lists.map((list) => (
+                        <li key={list.id} className="px-3 py-2">
+                          <Link
+                            href={`/lists/${list.id}`}
+                            className="text-wiki-link hover:underline font-medium focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
+                          >
+                            {list.name}
+                          </Link>
+                          {list.description && (
+                            <p className="text-xs text-wiki-text-muted mt-0.5 line-clamp-2">
+                              {list.description}
+                            </p>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                )}
+
+                {results.citations.length > 0 && (
+                  <section>
+                    <h2 className="text-lg font-semibold mb-2">
+                      Citations ({results.citations.length})
+                    </h2>
+                    <ul className="divide-y divide-wiki-border-light border border-wiki-border-light">
+                      {results.citations.map((citation) => (
+                        <li key={citation.id} className="px-3 py-2">
+                          <Link
+                            href={`/lists/${citation.listId}`}
+                            className="text-wiki-link hover:underline font-medium focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
+                          >
+                            {citation.title || "Untitled"}
+                          </Link>
+                          <p className="citation-text text-xs text-wiki-text-muted mt-0.5 line-clamp-2">
+                            {citation.formattedText}
+                          </p>
+                          <p className="text-xs text-wiki-text-muted mt-0.5">
+                            In list:{" "}
+                            <span className="font-medium">{citation.listName}</span>
+                          </p>
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                )}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </WikiLayout>
+  );
+}
+
+export default function SearchPage() {
+  return (
+    <Suspense
+      fallback={
+        <WikiLayout>
+          <div className="flex items-center justify-center py-12">
+            <span className="text-sm text-wiki-text-muted">Loading…</span>
+          </div>
+        </WikiLayout>
+      }
+    >
+      <SearchPageContent />
+    </Suspense>
+  );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { WikiLayout } from "@/components/wiki/wiki-layout";
+import { WikiBreadcrumbs } from "@/components/wiki/wiki-breadcrumbs";
+import { WikiButton } from "@/components/wiki/wiki-button";
+import { WikiSelect } from "@/components/wiki/wiki-select";
+import { CSL_STYLES } from "@/lib/citation";
+import { SOURCE_TYPES, CITATION_STYLES, ACCESS_TYPES } from "@/lib/citation-options";
+import {
+  getPreferences,
+  savePreferences,
+  DEFAULT_PREFERENCES,
+  type Preferences,
+} from "@/lib/preferences";
+
+const STYLE_OPTIONS = [
+  ...CITATION_STYLES.map((s) => ({ value: s.value as string, label: s.label })),
+  ...CSL_STYLES.map((s) => ({ value: s.id, label: s.label })),
+];
+
+export default function SettingsPage() {
+  const [prefs, setPrefs] = useState<Preferences>(DEFAULT_PREFERENCES);
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+  const [mounted, setMounted] = useState(false);
+  const [savedFlash, setSavedFlash] = useState(false);
+  const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setPrefs(getPreferences());
+    setTheme(document.documentElement.classList.contains("dark") ? "dark" : "light");
+    setMounted(true);
+    return () => {
+      if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+    };
+  }, []);
+
+  const flashSaved = () => {
+    if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+    setSavedFlash(true);
+    flashTimerRef.current = setTimeout(() => setSavedFlash(false), 1500);
+  };
+
+  const update = (change: Partial<Preferences>) => {
+    setPrefs(savePreferences(change));
+    flashSaved();
+  };
+
+  const applyTheme = (next: "light" | "dark") => {
+    setTheme(next);
+    document.documentElement.classList.toggle("dark", next === "dark");
+    localStorage.setItem("opencitation-theme", next);
+    flashSaved();
+  };
+
+  return (
+    <WikiLayout>
+      <WikiBreadcrumbs
+        items={[{ label: "Home", href: "/" }, { label: "Settings" }]}
+      />
+
+      <div className="mt-6">
+        <div className="border border-wiki-border-light bg-wiki-white p-6 md:p-8">
+          <div className="flex items-center justify-between mb-1">
+            <h1 className="text-2xl font-bold">Settings</h1>
+            <span
+              role="status"
+              className={`text-sm text-wiki-text-muted ${savedFlash ? "" : "invisible"}`}
+            >
+              Saved
+            </span>
+          </div>
+          <p className="text-wiki-text-muted text-sm mb-6">
+            Preferences are saved automatically and stored on this device.
+          </p>
+
+          {mounted && (
+            <div className="space-y-8">
+              <section>
+                <h2 className="text-lg font-semibold mb-1">Citation Defaults</h2>
+                <p className="text-sm text-wiki-text-muted mb-4">
+                  Applied when you open the citation generator.
+                </p>
+                <div className="space-y-4 max-w-xs">
+                  <div>
+                    <span id="default-style-label" className="block text-sm font-medium mb-1">
+                      Default citation style
+                    </span>
+                    <WikiSelect
+                      aria-labelledby="default-style-label"
+                      value={prefs.defaultStyle}
+                      onChange={(v) => update({ defaultStyle: v })}
+                      options={STYLE_OPTIONS}
+                      className="w-full"
+                    />
+                  </div>
+                  <div>
+                    <span id="default-source-type-label" className="block text-sm font-medium mb-1">
+                      Default source type
+                    </span>
+                    <WikiSelect
+                      aria-labelledby="default-source-type-label"
+                      value={prefs.defaultSourceType}
+                      onChange={(v) => update({ defaultSourceType: v as Preferences["defaultSourceType"] })}
+                      options={SOURCE_TYPES}
+                      className="w-full"
+                    />
+                  </div>
+                  <div>
+                    <span id="default-access-type-label" className="block text-sm font-medium mb-1">
+                      Default access type
+                    </span>
+                    <WikiSelect
+                      aria-labelledby="default-access-type-label"
+                      value={prefs.defaultAccessType}
+                      onChange={(v) => update({ defaultAccessType: v as Preferences["defaultAccessType"] })}
+                      options={ACCESS_TYPES}
+                      className="w-full"
+                    />
+                  </div>
+                </div>
+              </section>
+
+              <section className="pt-6 border-t border-wiki-border-light">
+                <h2 className="text-lg font-semibold mb-1">Appearance</h2>
+                <p className="text-sm text-wiki-text-muted mb-4">
+                  Also available from the sun/moon toggle in the header.
+                </p>
+                <div className="flex gap-2">
+                  <WikiButton
+                    variant={theme === "light" ? "primary" : "default"}
+                    className={theme === "light" ? "border-wiki-link" : ""}
+                    onClick={() => applyTheme("light")}
+                  >
+                    Light
+                  </WikiButton>
+                  <WikiButton
+                    variant={theme === "dark" ? "primary" : "default"}
+                    className={theme === "dark" ? "border-wiki-link" : ""}
+                    onClick={() => applyTheme("dark")}
+                  >
+                    Dark
+                  </WikiButton>
+                </div>
+              </section>
+            </div>
+          )}
+        </div>
+      </div>
+    </WikiLayout>
+  );
+}

--- a/src/components/wiki/index.ts
+++ b/src/components/wiki/index.ts
@@ -4,5 +4,6 @@ export { WikiButton } from "./wiki-button";
 export { WikiBreadcrumbs } from "./wiki-breadcrumbs";
 export { WikiCollapsible } from "./wiki-collapsible";
 export { WikiUserMenu } from "./wiki-user-menu";
+export { WikiCommandPalette } from "./wiki-command-palette";
 export { ShareDialog } from "./share-dialog";
 export { WikiDocsSidebar } from "./docs-sidebar";

--- a/src/components/wiki/wiki-command-palette.tsx
+++ b/src/components/wiki/wiki-command-palette.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { useUser } from "@clerk/nextjs";
+import { fuzzyMatch } from "@/lib/fuzzy-match";
+
+interface PaletteCommand {
+  id: string;
+  label: string;
+  /** Section heading shown when the query is empty. */
+  section: string;
+  /** Extra text matched against the query but not displayed. */
+  keywords?: string;
+  /** Right-aligned hint, e.g. the destination path. */
+  hint?: string;
+  perform: () => void;
+}
+
+interface WikiCommandPaletteProps {
+  onToggleTheme: () => void;
+}
+
+const MAX_RESULTS = 12;
+
+export function WikiCommandPalette({ onToggleTheme }: WikiCommandPaletteProps) {
+  const router = useRouter();
+  const { isSignedIn } = useUser();
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [dynamicCommands, setDynamicCommands] = useState<PaletteCommand[]>([]);
+  const fetchedRef = useRef(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setQuery("");
+    setSelectedIndex(0);
+    previousFocusRef.current?.focus();
+  }, []);
+
+  const go = useCallback(
+    (href: string) => () => router.push(href),
+    [router]
+  );
+
+  const staticCommands = useMemo<PaletteCommand[]>(() => {
+    const nav: PaletteCommand[] = [];
+    if (isSignedIn) {
+      nav.push(
+        { id: "nav-dashboard", label: "Dashboard", section: "Navigate", hint: "/home", keywords: "home overview", perform: go("/home") },
+        { id: "nav-cite", label: "Cite", section: "Navigate", hint: "/cite", keywords: "new citation generate url doi isbn", perform: go("/cite") },
+        { id: "nav-lists", label: "My Lists", section: "Navigate", hint: "/lists", keywords: "citations bibliography", perform: go("/lists") },
+        { id: "nav-projects", label: "My Projects", section: "Navigate", hint: "/projects", perform: go("/projects") },
+        { id: "nav-search", label: "Search everything", section: "Navigate", hint: "/search", keywords: "find global citations lists projects", perform: go("/search") },
+      );
+    } else {
+      nav.push(
+        { id: "nav-cite", label: "Cite", section: "Navigate", hint: "/cite", keywords: "new citation generate url doi isbn", perform: go("/cite") },
+        { id: "nav-sign-in", label: "Sign In", section: "Navigate", hint: "/sign-in", keywords: "login account", perform: go("/sign-in") },
+        { id: "nav-sign-up", label: "Create Account", section: "Navigate", hint: "/sign-up", keywords: "register signup", perform: go("/sign-up") },
+      );
+    }
+    nav.push(
+      { id: "nav-settings", label: "Settings", section: "Navigate", hint: "/settings", keywords: "preferences defaults style theme", perform: go("/settings") },
+      { id: "nav-docs", label: "Documentation", section: "Navigate", hint: "/docs", keywords: "help guide docs", perform: go("/docs") },
+      { id: "nav-shortcuts", label: "Keyboard Shortcuts", section: "Navigate", hint: "/docs/keyboard-shortcuts", keywords: "keys hotkeys", perform: go("/docs/keyboard-shortcuts") },
+      { id: "nav-changelog", label: "Changelog", section: "Navigate", hint: "/docs/changelog", keywords: "news updates releases", perform: go("/docs/changelog") },
+    );
+    nav.push({
+      id: "action-theme",
+      label: "Toggle Dark Mode",
+      section: "Actions",
+      keywords: "theme light dark appearance",
+      perform: onToggleTheme,
+    });
+    return nav;
+  }, [isSignedIn, go, onToggleTheme]);
+
+  // Fetch lists and projects once per session, the first time the palette opens.
+  useEffect(() => {
+    if (!isOpen || !isSignedIn || fetchedRef.current) return;
+    fetchedRef.current = true;
+    (async () => {
+      try {
+        const [listsRes, projectsRes] = await Promise.all([
+          fetch("/api/lists"),
+          fetch("/api/projects"),
+        ]);
+        const [lists, projects] = await Promise.all([listsRes.json(), projectsRes.json()]);
+        const commands: PaletteCommand[] = [];
+        if (lists.success) {
+          for (const list of lists.data as Array<{ id: string; name: string }>) {
+            commands.push({
+              id: `list-${list.id}`,
+              label: list.name,
+              section: "Lists",
+              keywords: "list open go",
+              perform: go(`/lists/${list.id}`),
+            });
+          }
+        }
+        if (projects.success) {
+          for (const project of projects.data as Array<{ id: string; name: string }>) {
+            commands.push({
+              id: `project-${project.id}`,
+              label: project.name,
+              section: "Projects",
+              keywords: "project open go",
+              perform: go(`/projects/${project.id}`),
+            });
+          }
+        }
+        setDynamicCommands(commands);
+      } catch {
+        // Offline or unauthenticated — static commands still work.
+      }
+    })();
+  }, [isOpen, isSignedIn, go]);
+
+  const results = useMemo(() => {
+    const all = [...staticCommands, ...dynamicCommands];
+    if (!query.trim()) return all.slice(0, MAX_RESULTS);
+    return all
+      .map((command) => {
+        const match = fuzzyMatch(query, `${command.label} ${command.keywords ?? ""}`);
+        return match ? { command, score: match.score } : null;
+      })
+      .filter((r): r is { command: PaletteCommand; score: number } => r !== null)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, MAX_RESULTS)
+      .map((r) => r.command);
+  }, [query, staticCommands, dynamicCommands]);
+
+  // Global ⌘K / Ctrl+K listener (also works while typing in inputs).
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key.toLowerCase() === "k" &&
+        (event.metaKey || event.ctrlKey) &&
+        !event.altKey &&
+        !event.shiftKey
+      ) {
+        event.preventDefault();
+        setIsOpen((open) => {
+          if (!open) previousFocusRef.current = document.activeElement as HTMLElement;
+          return !open;
+        });
+        setQuery("");
+        setSelectedIndex(0);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) inputRef.current?.focus();
+  }, [isOpen]);
+
+  // Keep the selected option scrolled into view.
+  useEffect(() => {
+    listRef.current
+      ?.querySelector(`[data-index="${selectedIndex}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  const run = (command: PaletteCommand) => {
+    close();
+    command.perform();
+  };
+
+  const handleInputKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      close();
+    } else if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setSelectedIndex((i) => (results.length ? (i + 1) % results.length : 0));
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setSelectedIndex((i) => (results.length ? (i - 1 + results.length) % results.length : 0));
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      if (results[selectedIndex]) run(results[selectedIndex]);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  // Section heading appears above the first command of each section, browse mode only.
+  const showSections = !query.trim();
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-start justify-center pt-[15vh] z-50"
+      onClick={close}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command palette"
+        className="bg-wiki-white border border-wiki-border-light max-w-xl w-full mx-4 shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="border-b border-wiki-border-light">
+          <input
+            ref={inputRef}
+            type="text"
+            role="combobox"
+            aria-expanded="true"
+            aria-controls="command-palette-results"
+            aria-activedescendant={
+              results[selectedIndex] ? `command-${results[selectedIndex].id}` : undefined
+            }
+            aria-label="Type a command or search"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setSelectedIndex(0);
+            }}
+            onKeyDown={handleInputKeyDown}
+            placeholder="Type a command or search..."
+            className="w-full px-4 py-3 text-sm bg-wiki-white border-0 focus:outline-none"
+            autoComplete="off"
+            spellCheck={false}
+          />
+        </div>
+        <div
+          ref={listRef}
+          id="command-palette-results"
+          role="listbox"
+          aria-label="Commands"
+          className="max-h-80 overflow-y-auto"
+        >
+          {results.length === 0 ? (
+            <p className="px-4 py-6 text-sm text-wiki-text-muted text-center">
+              No matching commands.
+            </p>
+          ) : (
+            results.map((command, index) => (
+              <div key={command.id}>
+                {showSections &&
+                  (index === 0 || results[index - 1].section !== command.section) && (
+                    <div className="px-4 pt-2 pb-1 text-xs font-medium text-wiki-text-muted uppercase tracking-wide">
+                      {command.section}
+                    </div>
+                  )}
+                <button
+                  type="button"
+                  id={`command-${command.id}`}
+                  data-index={index}
+                  role="option"
+                  aria-selected={index === selectedIndex}
+                  className={`w-full flex items-center justify-between gap-3 px-4 py-2 text-sm text-left focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text ${
+                    index === selectedIndex ? "bg-wiki-tab-bg" : "hover:bg-wiki-offwhite"
+                  }`}
+                  onClick={() => run(command)}
+                  onMouseMove={() => setSelectedIndex(index)}
+                >
+                  <span className="text-wiki-link truncate">{command.label}</span>
+                  <span className="text-xs text-wiki-text-muted shrink-0">
+                    {command.hint ?? (!showSections ? command.section : "")}
+                  </span>
+                </button>
+              </div>
+            ))
+          )}
+        </div>
+        <div className="px-4 py-2 border-t border-wiki-border-light text-xs text-wiki-text-muted flex gap-4">
+          <span><kbd>↑↓</kbd> navigate</span>
+          <span><kbd>Enter</kbd> select</span>
+          <span><kbd>Esc</kbd> close</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/wiki/wiki-layout.tsx
+++ b/src/components/wiki/wiki-layout.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { SignedIn, SignedOut } from "@clerk/nextjs";
 import { WikiUserMenu } from "./wiki-user-menu";
+import { WikiCommandPalette } from "./wiki-command-palette";
 
 interface WikiLayoutProps {
   children: React.ReactNode;
@@ -111,6 +112,8 @@ export function WikiLayout({ children, hideFooter = false }: WikiLayoutProps) {
 
   return (
     <div className="min-h-screen bg-wiki-white">
+      <WikiCommandPalette onToggleTheme={toggle} />
+
       {/* Skip navigation — WCAG 2.4.1 */}
       <a
         href="#main-content"
@@ -188,6 +191,9 @@ export function WikiLayout({ children, hideFooter = false }: WikiLayoutProps) {
               </Link>
               <Link href="/projects" className="text-wiki-link hover:underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text">
                 Projects
+              </Link>
+              <Link href="/search" className="text-wiki-link hover:underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text">
+                Search
               </Link>
               <div ref={docsRef} className="relative">
                 <button
@@ -319,6 +325,13 @@ export function WikiLayout({ children, hideFooter = false }: WikiLayoutProps) {
                   onClick={() => setMobileMenuOpen(false)}
                 >
                   My Projects
+                </Link>
+                <Link
+                  href="/search"
+                  className="text-wiki-link hover:underline py-1 focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
+                  onClick={() => setMobileMenuOpen(false)}
+                >
+                  Search
                 </Link>
               </SignedIn>
               <a

--- a/src/components/wiki/wiki-user-menu.tsx
+++ b/src/components/wiki/wiki-user-menu.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from "react";
 import { useUser, useClerk } from "@clerk/nextjs";
 import Image from "next/image";
+import Link from "next/link";
 
 interface WikiUserMenuProps {
   size?: "sm" | "md";
@@ -98,6 +99,13 @@ export function WikiUserMenu({ size = "md" }: WikiUserMenuProps) {
 
           {/* Menu Items */}
           <div className="py-1">
+            <Link
+              href="/settings"
+              onClick={() => setIsOpen(false)}
+              className="block w-full text-left px-3 py-1.5 text-sm text-wiki-link hover:bg-wiki-offwhite hover:underline focus-visible:outline-dotted focus-visible:outline-1 focus-visible:outline-wiki-text"
+            >
+              Settings
+            </Link>
             <button
               onClick={() => {
                 openUserProfile();

--- a/src/lib/citation-options.ts
+++ b/src/lib/citation-options.ts
@@ -1,0 +1,52 @@
+import type { CitationStyle, SourceType, AccessType } from "@/types";
+
+/**
+ * Shared option lists for the cite page and settings page.
+ * CSL styles (IEEE, Vancouver, …) live in `@/lib/citation` as CSL_STYLES.
+ */
+
+export const SOURCE_TYPES: { value: SourceType; label: string }[] = [
+  { value: "book", label: "Book" },
+  { value: "book-chapter", label: "Book Chapter" },
+  { value: "journal", label: "Journal" },
+  { value: "website", label: "Website" },
+  { value: "blog", label: "Blog" },
+  { value: "newspaper", label: "Newspaper" },
+  { value: "video", label: "Video" },
+  { value: "image", label: "Image" },
+  { value: "film", label: "Film" },
+  { value: "tv-series", label: "TV Series" },
+  { value: "tv-episode", label: "TV Episode" },
+  { value: "song", label: "Song" },
+  { value: "album", label: "Album" },
+  { value: "podcast-episode", label: "Podcast Episode" },
+  { value: "video-game", label: "Video Game" },
+  { value: "artwork", label: "Artwork" },
+  { value: "thesis", label: "Thesis / Dissertation" },
+  { value: "conference-paper", label: "Conference Paper" },
+  { value: "dataset", label: "Dataset" },
+  { value: "software", label: "Software / Code" },
+  { value: "preprint", label: "Preprint" },
+  { value: "social-media", label: "Social Media" },
+  { value: "ai-generated", label: "AI-Generated" },
+  { value: "interview", label: "Interview" },
+  { value: "government-report", label: "Government Report" },
+  { value: "legal-case", label: "Legal Case" },
+  { value: "encyclopedia", label: "Encyclopedia" },
+  { value: "miscellaneous", label: "Miscellaneous" },
+];
+
+export const CITATION_STYLES: { value: CitationStyle; label: string }[] = [
+  { value: "apa", label: "APA 7th" },
+  { value: "mla", label: "MLA 9th" },
+  { value: "chicago", label: "Chicago 17th" },
+  { value: "harvard", label: "Harvard" },
+];
+
+export const ACCESS_TYPES: { value: AccessType; label: string }[] = [
+  { value: "web", label: "Web" },
+  { value: "print", label: "Print" },
+  { value: "database", label: "Database" },
+  { value: "app", label: "App" },
+  { value: "archive", label: "Archive" },
+];

--- a/src/lib/citation/importers/ris.test.ts
+++ b/src/lib/citation/importers/ris.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import { parseAllRIS, looksLikeRIS } from "./ris";
+import { toRIS } from "../exporters/ris";
+import type { JournalFields } from "@/types";
+
+const JOURNAL_RECORD = `TY  - JOUR
+AU  - Smith, Jane A.
+AU  - Doe, John
+TI  - On the Citation of Things
+T2  - Journal of Examples
+PY  - 2023/05/14/
+VL  - 12
+IS  - 3
+SP  - 45
+EP  - 67
+SN  - 1234-5678
+DO  - 10.1000/xyz123
+UR  - https://example.com/article
+AB  - A study of citations.
+ER  - `;
+
+describe("parseAllRIS", () => {
+  it("parses a journal record", () => {
+    const results = parseAllRIS(JOURNAL_RECORD);
+    expect(results).toHaveLength(1);
+
+    const { fields, entryType, entryKey } = results[0];
+    expect(entryType).toBe("JOUR");
+    expect(entryKey).toBe("smith2023");
+    expect(fields.sourceType).toBe("journal");
+    expect(fields.title).toBe("On the Citation of Things");
+    expect(fields.authors).toEqual([
+      { lastName: "Smith", firstName: "Jane", middleName: "A." },
+      { lastName: "Doe", firstName: "John", middleName: undefined },
+    ]);
+    expect(fields.publicationDate).toEqual({ year: 2023, month: 5, day: 14 });
+    expect(fields.url).toBe("https://example.com/article");
+    expect(fields.doi).toBe("10.1000/xyz123");
+    expect(fields.annotation).toBe("A study of citations.");
+    expect(fields.accessType).toBe("web");
+
+    const journal = fields as JournalFields;
+    expect(journal.journalTitle).toBe("Journal of Examples");
+    expect(journal.volume).toBe("12");
+    expect(journal.issue).toBe("3");
+    expect(journal.pageRange).toBe("45-67");
+    expect(journal.issn).toBe("1234-5678");
+  });
+
+  it("parses a book record with ISBN and edition", () => {
+    const results = parseAllRIS(`TY  - BOOK
+AU  - Turabian, Kate L.
+TI  - A Manual for Writers
+ET  - 9
+PB  - University of Chicago Press
+CY  - Chicago
+PY  - 2018
+SN  - 978-0-226-43057-7
+ER  - `);
+    expect(results).toHaveLength(1);
+    const { fields } = results[0];
+    expect(fields.sourceType).toBe("book");
+    expect(fields.publisher).toBe("University of Chicago Press");
+    expect(fields.publicationPlace).toBe("Chicago");
+    expect(fields.publicationDate).toEqual({ year: 2018, month: undefined, day: undefined });
+    expect(fields.accessType).toBe("print");
+    expect("isbn" in fields && fields.isbn).toBe("978-0-226-43057-7");
+    expect("edition" in fields && fields.edition).toBe("9");
+  });
+
+  it("parses a book chapter with editors and pages", () => {
+    const results = parseAllRIS(`TY  - CHAP
+AU  - Author, Amy
+ED  - Editor, Ed
+TI  - Chapter Title
+T2  - The Big Book
+SP  - 100
+EP  - 120
+PY  - 2020
+ER  - `);
+    const { fields } = results[0];
+    expect(fields.sourceType).toBe("book-chapter");
+    expect("bookTitle" in fields && fields.bookTitle).toBe("The Big Book");
+    expect("pageRange" in fields && fields.pageRange).toBe("100-120");
+    expect(fields.editors).toEqual([
+      { lastName: "Editor", firstName: "Ed", middleName: undefined },
+    ]);
+  });
+
+  it("parses multiple records", () => {
+    const results = parseAllRIS(`${JOURNAL_RECORD}\n\nTY  - ELEC\nTI  - Some Web Page\nT2  - Example Site\nUR  - https://example.org\nER  - `);
+    expect(results).toHaveLength(2);
+    expect(results[1].fields.sourceType).toBe("website");
+    expect("siteName" in results[1].fields && results[1].fields.siteName).toBe("Example Site");
+    expect(results[1].entryKey).toBe("entry-2");
+  });
+
+  it("treats single-token and uncommaed multi-word names sensibly", () => {
+    const results = parseAllRIS(`TY  - RPRT
+AU  - World Health Organization
+TI  - Report Title
+ER  - `);
+    expect(results[0].fields.authors).toEqual([
+      { lastName: "World Health Organization", isOrganization: true },
+    ]);
+  });
+
+  it("joins wrapped continuation lines into the previous value", () => {
+    const results = parseAllRIS(`TY  - JOUR
+TI  - A Very Long Title That
+Wraps Onto The Next Line
+T2  - Journal
+ER  - `);
+    expect(results[0].fields.title).toBe("A Very Long Title That Wraps Onto The Next Line");
+  });
+
+  it("ignores unknown tags and missing ER on the final record", () => {
+    const results = parseAllRIS(`TY  - JOUR\nTI  - No Terminator\nXX  - mystery\nZ9  - whatever`);
+    expect(results).toHaveLength(1);
+    expect(results[0].fields.title).toBe("No Terminator");
+  });
+
+  it("returns an empty array for non-RIS input", () => {
+    expect(parseAllRIS("@article{key, title={x}}")).toEqual([]);
+    expect(parseAllRIS("")).toEqual([]);
+  });
+
+  it("maps preprint, thesis, and dataset types", () => {
+    const results = parseAllRIS(`TY  - UNPD
+TI  - Preprint
+M1  - 2301.00001
+PB  - arXiv
+ER  -
+TY  - THES
+TI  - Dissertation
+PB  - Example University
+M3  - PhD thesis
+ER  -
+TY  - DATA
+TI  - The Data
+ET  - 2.0
+ER  - `);
+    expect(results.map((r) => r.fields.sourceType)).toEqual(["preprint", "thesis", "dataset"]);
+    expect("preprintId" in results[0].fields && results[0].fields.preprintId).toBe("2301.00001");
+    expect("institution" in results[1].fields && results[1].fields.institution).toBe("Example University");
+    expect("degree" in results[1].fields && results[1].fields.degree).toBe("doctoral");
+    expect("version" in results[2].fields && results[2].fields.version).toBe("2.0");
+  });
+
+  it("round-trips a journal citation through the RIS exporter", () => {
+    const original = parseAllRIS(JOURNAL_RECORD)[0].fields;
+    const reparsed = parseAllRIS(toRIS(original))[0].fields;
+    expect(reparsed).toEqual(original);
+  });
+});
+
+describe("looksLikeRIS", () => {
+  it("detects RIS input", () => {
+    expect(looksLikeRIS(JOURNAL_RECORD)).toBe(true);
+    expect(looksLikeRIS("TY - JOUR\nER - ")).toBe(true);
+  });
+
+  it("rejects BibTeX input", () => {
+    expect(looksLikeRIS("@article{smith2024,\n title={X}\n}")).toBe(false);
+    expect(looksLikeRIS("")).toBe(false);
+  });
+});

--- a/src/lib/citation/importers/ris.ts
+++ b/src/lib/citation/importers/ris.ts
@@ -1,0 +1,430 @@
+import type { Author, CitationDate, CitationFields, SourceType } from "@/types";
+
+/**
+ * RIS importer — counterpart to `exporters/ris.ts`.
+ * Zotero, EndNote, and Mendeley all export this format.
+ */
+
+export interface RISParseResult {
+  fields: CitationFields;
+  /** The raw RIS reference type, e.g. "JOUR". */
+  entryType: string;
+  /** Derived key (first author + year) for display, like a BibTeX citekey. */
+  entryKey: string;
+}
+
+function risTypeToSourceType(risType: string): SourceType {
+  switch (risType.toUpperCase()) {
+    case "JOUR":
+    case "JFULL":
+    case "MGZN":
+    case "ABST":
+      return "journal";
+    case "BOOK":
+    case "EDBOOK":
+      return "book";
+    case "CHAP":
+      return "book-chapter";
+    case "CPAPER":
+    case "CONF":
+      return "conference-paper";
+    case "THES":
+      return "thesis";
+    case "RPRT":
+      return "government-report";
+    case "NEWS":
+      return "newspaper";
+    case "BLOG":
+      return "blog";
+    case "ELEC":
+    case "WEB":
+      return "website";
+    case "VIDEO":
+    case "ADVS":
+      return "video";
+    case "MPCT":
+      return "film";
+    case "MUSIC":
+      return "song";
+    case "SOUND":
+      return "podcast-episode";
+    case "ART":
+      return "artwork";
+    case "DATA":
+    case "DBASE":
+      return "dataset";
+    case "COMP":
+      return "software";
+    case "UNPD":
+      return "preprint";
+    case "ENCYC":
+      return "encyclopedia";
+    case "CASE":
+      return "legal-case";
+    case "INTV":
+      return "interview";
+    default:
+      return "miscellaneous";
+  }
+}
+
+/**
+ * Parse an RIS person name: "Last, First Middle" or "Last, F.M." or a
+ * single token. Names without a comma and with multiple words are treated
+ * as corporate authors (the RIS convention is comma-separated for people).
+ */
+function parseRISName(raw: string): Author | null {
+  const name = raw.trim();
+  if (!name) return null;
+
+  if (name.includes(",")) {
+    const [last, rest = ""] = name.split(",").map((s) => s.trim());
+    if (!last) return null;
+    const parts = rest.split(/\s+/).filter(Boolean);
+    const [firstName, ...middleParts] = parts;
+    return {
+      lastName: last,
+      firstName: firstName || undefined,
+      middleName: middleParts.length > 0 ? middleParts.join(" ") : undefined,
+    };
+  }
+
+  const parts = name.split(/\s+/).filter(Boolean);
+  if (parts.length === 1) return { lastName: parts[0] };
+  return { lastName: name, isOrganization: true };
+}
+
+/** Parse an RIS date: "YYYY/MM/DD/other info" — any segment may be empty. */
+function parseRISDate(raw: string): CitationDate | undefined {
+  const [yearStr, monthStr, dayStr] = raw.trim().split("/");
+  const year = /^\d{4}$/.test(yearStr ?? "") ? parseInt(yearStr, 10) : undefined;
+  if (!year) return undefined;
+  const month = /^\d{1,2}$/.test(monthStr ?? "") ? parseInt(monthStr, 10) : undefined;
+  const day = /^\d{1,2}$/.test(dayStr ?? "") ? parseInt(dayStr, 10) : undefined;
+  return {
+    year,
+    month: month && month >= 1 && month <= 12 ? month : undefined,
+    day: day && day >= 1 && day <= 31 ? day : undefined,
+  };
+}
+
+const TAG_LINE = /^([A-Z][A-Z0-9])\s{1,2}-\s?(.*)$/;
+
+interface RawRecord {
+  type: string;
+  /** Tag → all values seen for that tag, in order. */
+  tags: Map<string, string[]>;
+}
+
+/** Split RIS text into raw records (TY ... ER blocks). */
+function splitRecords(input: string): RawRecord[] {
+  const records: RawRecord[] = [];
+  let current: RawRecord | null = null;
+  let lastValues: string[] | null = null;
+
+  for (const rawLine of input.split(/\r?\n/)) {
+    const line = rawLine.replace(/^\uFEFF/, ""); // strip BOM
+    const match = line.match(TAG_LINE);
+
+    if (!match) {
+      // Continuation of the previous value (long abstracts wrap lines).
+      const text = line.trim();
+      if (current && lastValues && lastValues.length > 0 && text) {
+        lastValues[lastValues.length - 1] += ` ${text}`;
+      }
+      continue;
+    }
+
+    const [, tag, value] = match;
+    if (tag === "TY") {
+      current = { type: value.trim(), tags: new Map() };
+      lastValues = null;
+      continue;
+    }
+    if (tag === "ER") {
+      if (current) records.push(current);
+      current = null;
+      lastValues = null;
+      continue;
+    }
+    if (!current) continue;
+    const values = current.tags.get(tag) ?? [];
+    values.push(value.trim());
+    current.tags.set(tag, values);
+    lastValues = values;
+  }
+
+  if (current && current.tags.size > 0) records.push(current);
+  return records;
+}
+
+function first(record: RawRecord, ...tags: string[]): string | undefined {
+  for (const tag of tags) {
+    const values = record.tags.get(tag);
+    if (values && values[0]) return values[0];
+  }
+  return undefined;
+}
+
+function all(record: RawRecord, ...tags: string[]): string[] {
+  const result: string[] = [];
+  for (const tag of tags) {
+    for (const value of record.tags.get(tag) ?? []) {
+      if (value) result.push(value);
+    }
+  }
+  return result;
+}
+
+function parsePersons(record: RawRecord, ...tags: string[]): Author[] | undefined {
+  const authors = all(record, ...tags)
+    .map(parseRISName)
+    .filter((a): a is Author => a !== null);
+  return authors.length > 0 ? authors : undefined;
+}
+
+function deriveEntryKey(authors: Author[] | undefined, date: CitationDate | undefined, index: number): string {
+  const name = authors?.[0]?.lastName.split(/\s+/)[0]?.toLowerCase().replace(/[^a-z0-9]/g, "");
+  if (name) return date?.year ? `${name}${date.year}` : name;
+  return `entry-${index + 1}`;
+}
+
+function buildFields(record: RawRecord): CitationFields {
+  const sourceType = risTypeToSourceType(record.type);
+
+  const authors = parsePersons(record, "AU", "A1");
+  const editors = parsePersons(record, "ED");
+  const translators = parsePersons(record, "A4");
+
+  const dateRaw = first(record, "PY", "Y1", "DA");
+  const publicationDate = dateRaw ? parseRISDate(dateRaw) : undefined;
+  const accessRaw = first(record, "Y2");
+  const accessDate = accessRaw ? parseRISDate(accessRaw) : undefined;
+
+  const startPage = first(record, "SP");
+  const endPage = first(record, "EP");
+  const pageRange = startPage ? (endPage ? `${startPage}-${endPage}` : startPage) : undefined;
+
+  const title = first(record, "TI", "T1") ?? "";
+  const secondary = first(record, "T2", "JO", "JF", "JA");
+  const tertiary = first(record, "T3");
+  const volume = first(record, "VL");
+  const issue = first(record, "IS");
+  const edition = first(record, "ET");
+  const publisher = first(record, "PB");
+  const place = first(record, "CY");
+  const serialNumber = first(record, "SN");
+  const url = first(record, "UR");
+  const doi = first(record, "DO", "DI");
+  const annotation = first(record, "AB", "N2");
+  const language = first(record, "LA");
+  const misc1 = first(record, "M1");
+  const misc3 = first(record, "M3");
+
+  const base = {
+    title: title || "Untitled",
+    authors,
+    editors,
+    translators,
+    publisher,
+    publicationPlace: place,
+    publicationDate,
+    accessDate,
+    url,
+    doi,
+    annotation,
+    language,
+    accessType: (url ? "web" : "print") as "web" | "print",
+  };
+
+  switch (sourceType) {
+    case "journal":
+      return {
+        ...base,
+        sourceType: "journal",
+        journalTitle: secondary || "Unknown Journal",
+        volume,
+        issue,
+        pageRange,
+        issn: serialNumber,
+      };
+    case "book":
+      return {
+        ...base,
+        sourceType: "book",
+        isbn: serialNumber,
+        edition,
+        volume,
+        series: tertiary,
+        pageRange,
+      };
+    case "book-chapter":
+      return {
+        ...base,
+        sourceType: "book-chapter",
+        bookTitle: secondary || "Unknown Book",
+        bookEditors: editors,
+        pageRange,
+        edition,
+        volume,
+        isbn: serialNumber,
+      };
+    case "conference-paper":
+      return {
+        ...base,
+        sourceType: "conference-paper",
+        conferenceName: secondary || "Unknown Conference",
+        conferenceLocation: place,
+        proceedingsTitle: tertiary,
+        pageRange,
+      };
+    case "thesis":
+      return {
+        ...base,
+        sourceType: "thesis",
+        institution: publisher,
+        department: tertiary,
+        degree:
+          misc3 && /phd|doctor/i.test(misc3)
+            ? "doctoral"
+            : misc3 && /master/i.test(misc3)
+              ? "masters"
+              : undefined,
+      };
+    case "government-report":
+      return {
+        ...base,
+        sourceType: "government-report",
+        agency: publisher,
+        reportNumber: misc1,
+        series: tertiary,
+      };
+    case "newspaper":
+      return {
+        ...base,
+        sourceType: "newspaper",
+        newspaperTitle: secondary || "Unknown Newspaper",
+        pageRange,
+        edition,
+      };
+    case "blog":
+      return {
+        ...base,
+        sourceType: "blog",
+        blogName: secondary || "Unknown Blog",
+      };
+    case "website":
+      return {
+        ...base,
+        sourceType: "website",
+        siteName: secondary,
+        // ELEC records usually describe an online resource even without UR.
+        accessType: "web",
+      };
+    case "video":
+      return {
+        ...base,
+        sourceType: "video",
+        channelName: secondary,
+      };
+    case "film":
+      return {
+        ...base,
+        sourceType: "film",
+      };
+    case "song":
+      return {
+        ...base,
+        sourceType: "song",
+        album: secondary,
+        trackNumber: misc1,
+      };
+    case "podcast-episode":
+      return {
+        ...base,
+        sourceType: "podcast-episode",
+        showName: secondary || "Unknown Show",
+        episodeNumber: issue,
+        seasonNumber: volume,
+      };
+    case "artwork":
+      return {
+        ...base,
+        sourceType: "artwork",
+        medium: misc3,
+        museum: publisher,
+        city: place,
+      };
+    case "dataset":
+      return {
+        ...base,
+        sourceType: "dataset",
+        version: edition,
+        repository: publisher,
+      };
+    case "software":
+      return {
+        ...base,
+        sourceType: "software",
+        version: edition,
+        repository: publisher,
+        license: misc3,
+      };
+    case "preprint":
+      return {
+        ...base,
+        sourceType: "preprint",
+        repository: publisher,
+        preprintId: misc1,
+        version: edition,
+      };
+    case "encyclopedia":
+      return {
+        ...base,
+        sourceType: "encyclopedia",
+        encyclopediaTitle: secondary || "Unknown Encyclopedia",
+        edition,
+        volume,
+        pageRange,
+      };
+    case "legal-case":
+      return {
+        ...base,
+        sourceType: "legal-case",
+        court: publisher,
+        citationNumber: misc1,
+        jurisdiction: misc3,
+      };
+    case "interview":
+      return {
+        ...base,
+        sourceType: "interview",
+        interviewee: authors,
+      };
+    default:
+      return {
+        ...base,
+        sourceType: "miscellaneous",
+      };
+  }
+}
+
+/**
+ * Parse all RIS records from a string (e.g. the contents of a .ris file).
+ * Malformed lines are ignored; records without a TY tag are skipped.
+ */
+export function parseAllRIS(input: string): RISParseResult[] {
+  return splitRecords(input).map((record, index) => {
+    const fields = buildFields(record);
+    return {
+      fields,
+      entryType: record.type,
+      entryKey: deriveEntryKey(fields.authors, fields.publicationDate, index),
+    };
+  });
+}
+
+/** Heuristic: does this text look like RIS (vs. BibTeX)? */
+export function looksLikeRIS(input: string): boolean {
+  return /^TY\s{1,2}-/m.test(input.trim());
+}

--- a/src/lib/fuzzy-match.test.ts
+++ b/src/lib/fuzzy-match.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { fuzzyMatch } from "./fuzzy-match";
+
+describe("fuzzyMatch", () => {
+  it("matches an empty query against anything with score 0", () => {
+    expect(fuzzyMatch("", "My Lists")).toEqual({ score: 0, indices: [] });
+    expect(fuzzyMatch("   ", "My Lists")).toEqual({ score: 0, indices: [] });
+  });
+
+  it("returns null when the query cannot match", () => {
+    expect(fuzzyMatch("xyz", "My Lists")).toBeNull();
+    expect(fuzzyMatch("listss", "lists")).toBeNull();
+    expect(fuzzyMatch("ba", "ab")).toBeNull(); // order matters
+  });
+
+  it("is case-insensitive", () => {
+    expect(fuzzyMatch("LISTS", "My Lists")).not.toBeNull();
+    expect(fuzzyMatch("lists", "MY LISTS")).not.toBeNull();
+  });
+
+  it("returns matched indices for substring matches", () => {
+    const result = fuzzyMatch("lists", "My Lists");
+    expect(result).not.toBeNull();
+    expect(result!.indices).toEqual([3, 4, 5, 6, 7]);
+  });
+
+  it("returns matched indices for subsequence matches", () => {
+    const result = fuzzyMatch("mls", "My Lists");
+    expect(result).not.toBeNull();
+    expect(result!.indices).toEqual([0, 3, 5]);
+  });
+
+  it("scores exact matches above prefix matches", () => {
+    const exact = fuzzyMatch("cite", "Cite")!;
+    const prefix = fuzzyMatch("cite", "Cite this page")!;
+    expect(exact.score).toBeGreaterThan(prefix.score);
+  });
+
+  it("scores substring matches above scattered subsequence matches", () => {
+    const substring = fuzzyMatch("port", "Import BibTeX")!;
+    const scattered = fuzzyMatch("port", "Projects orbit")!;
+    expect(substring.score).toBeGreaterThan(scattered.score);
+  });
+
+  it("prefers word-start matches", () => {
+    const wordStart = fuzzyMatch("ml", "My Lists")!;
+    const midWord = fuzzyMatch("ml", "html")!;
+    expect(wordStart.score).toBeGreaterThan(midWord.score);
+  });
+
+  it("prefers earlier substring matches", () => {
+    const early = fuzzyMatch("doc", "Documentation")!;
+    const late = fuzzyMatch("doc", "Read the docs")!;
+    // Word-aligned both; earlier position wins.
+    expect(early.score).toBeGreaterThan(late.score);
+  });
+});

--- a/src/lib/fuzzy-match.ts
+++ b/src/lib/fuzzy-match.ts
@@ -1,0 +1,58 @@
+/**
+ * Lightweight fuzzy matcher for the command palette.
+ *
+ * Case-insensitive. An exact substring match always beats a scattered
+ * subsequence match; word-start and consecutive-character matches score
+ * higher so "ml" prefers "My Lists" over "Bulk Import".
+ */
+
+export interface FuzzyResult {
+  score: number;
+  /** Indices into `target` of the matched characters (for highlighting). */
+  indices: number[];
+}
+
+const WORD_BOUNDARY = /[\s\-_/.:]/;
+
+export function fuzzyMatch(query: string, target: string): FuzzyResult | null {
+  const q = query.toLowerCase().trim();
+  const t = target.toLowerCase();
+
+  if (!q) return { score: 0, indices: [] };
+  if (q.length > t.length) return null;
+
+  // Exact substring: strong score, earlier and word-aligned is better.
+  const sub = t.indexOf(q);
+  if (sub !== -1) {
+    const wordAligned = sub === 0 || WORD_BOUNDARY.test(t[sub - 1]);
+    const score =
+      q.length === t.length ? 200 : (wordAligned ? 120 : 60) - sub;
+    return {
+      score,
+      indices: Array.from({ length: q.length }, (_, i) => sub + i),
+    };
+  }
+
+  // Subsequence: every query char must appear in order.
+  const indices: number[] = [];
+  let score = 0;
+  let ti = 0;
+  let prev = -2;
+  let allWordStarts = true;
+  for (const c of q) {
+    while (ti < t.length && t[ti] !== c) ti++;
+    if (ti >= t.length) return null;
+    score += 1;
+    if (ti === prev + 1) score += 5;
+    if (ti === 0 || WORD_BOUNDARY.test(t[ti - 1])) score += 10;
+    else allWordStarts = false;
+    indices.push(ti);
+    prev = ti;
+    ti++;
+  }
+  // Acronym match ("ml" → "My Lists") outranks a mid-word substring.
+  if (allWordStarts) score += 50;
+  // Penalize widely scattered matches.
+  score -= Math.floor((indices[indices.length - 1] - indices[0] - indices.length + 1) / 3);
+  return { score, indices };
+}

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -13,6 +13,7 @@ export interface Shortcut {
 
 export const SHORTCUTS: Shortcut[] = [
   // Global shortcuts
+  { key: "k", description: "Open command palette", modifiers: ["meta"], scope: "global" },
   { key: "?", description: "Show keyboard shortcuts", scope: "global" },
   { key: "/", description: "Focus search", scope: "global" },
   { key: "Escape", description: "Close modal / Cancel editing", scope: "global" },

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -1,0 +1,44 @@
+import type { SourceType, AccessType } from "@/types";
+
+/**
+ * Device-local user preferences, persisted in localStorage.
+ * (Theme has its own key, `opencitation-theme`, read pre-hydration.)
+ */
+
+export interface Preferences {
+  /** Built-in style id ("apa", …) or a CSL style id ("ieee", …). */
+  defaultStyle: string;
+  defaultSourceType: SourceType;
+  defaultAccessType: AccessType;
+}
+
+export const PREFERENCES_KEY = "opencitation-prefs";
+
+export const DEFAULT_PREFERENCES: Preferences = {
+  defaultStyle: "apa",
+  defaultSourceType: "website",
+  defaultAccessType: "web",
+};
+
+export function getPreferences(): Preferences {
+  if (typeof window === "undefined") return DEFAULT_PREFERENCES;
+  try {
+    const raw = localStorage.getItem(PREFERENCES_KEY);
+    if (!raw) return DEFAULT_PREFERENCES;
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return DEFAULT_PREFERENCES;
+    return { ...DEFAULT_PREFERENCES, ...parsed };
+  } catch {
+    return DEFAULT_PREFERENCES;
+  }
+}
+
+export function savePreferences(update: Partial<Preferences>): Preferences {
+  const next = { ...getPreferences(), ...update };
+  try {
+    localStorage.setItem(PREFERENCES_KEY, JSON.stringify(next));
+  } catch {
+    // Storage full or unavailable — preferences just won't persist.
+  }
+  return next;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,6 +6,7 @@ const isPublicRoute = createRouteMatcher([
   '/',
   '/cite',
   '/embed',
+  '/settings',
   '/sign-in(.*)',
   '/sign-up(.*)',
   '/share/(.*)',


### PR DESCRIPTION
## Summary

Four high-value, low-effort features for the power-user audience:

### Command palette (⌘K / Ctrl+K)
- `WikiCommandPalette` mounted in `WikiLayout`, available on every page
- Fuzzy-matched commands: navigation (Dashboard, Cite, Lists, Projects, Search, Settings, docs pages), theme toggle, and jump-to for the user's own lists and projects (fetched on first open)
- New `src/lib/fuzzy-match.ts` scorer: exact > word-aligned substring > acronym ("ml" → My Lists) > scattered subsequence
- Registered in `SHORTCUTS`, so it shows in the `?` overlay and the keyboard-shortcuts docs page automatically

### RIS import
- `src/lib/citation/importers/ris.ts` mirrors the BibTeX importer: 20+ TY types mapped to source types, authors/editors/translators, dates, page ranges, DOI, wrapped continuation lines, BOM handling, derived citekeys for the multi-entry picker
- Cite page tab renamed to "Import BibTeX / RIS" — format auto-detected on paste, `.ris` accepted on upload (closes the Zotero/EndNote/Mendeley interop gap)

### Settings page (`/settings`)
- Device-local defaults for citation style (built-ins + CSL), source type, access type, plus a theme picker — persisted via new `src/lib/preferences.ts`
- The cite page applies saved defaults on load (URL params still win)
- Option lists extracted to `src/lib/citation-options.ts`, shared between cite and settings; linked from the user menu and palette; public route since prefs are device-local

### Global search (`/search`)
- New `GET /api/search?q=` searches project/list names and descriptions plus citations (title, authors, formatted text, tags, notes) across all the user's lists, capped at 50 citation hits
- Debounced search page with grouped, linked results; "Search" added to the signed-in nav

## Testing
- 695 tests pass (27 new: fuzzy matcher, RIS importer, search API route)
- `lint`, `typecheck`, and `build` all clean locally
- Verified live in the browser: palette open/filter/Enter-navigation, settings persistence picked up by the cite page (IEEE default), RIS single- and multi-record import rendering correct citations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added global search functionality to find projects, lists, and citations across your account.
  * Added Settings page to configure default citation style, source type, access type, and theme preference.
  * Added Command Palette (⌘K/Ctrl+K) for quick navigation and theme switching.
  * Added RIS importer support alongside existing BibTeX import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->