### PR TITLE
⚡ Bolt: Optimize project detail data fetching to remove redundant API call

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Concurrent Fetching with Owner IDs in Share Links
 **Learning:** In the share system, endpoints processing a share code typically suffer from waterfall latency by first loading target entity details (like a project) and then querying its associated elements (like project lists) using the entity's owner ID (`userId`). However, the `shareLink` object already contains the `userId` field (representing the owner's ID).
 **Action:** Always leverage the existing owner's ID within `shareLink` to bypass sequential dependencies and fetch parent entities (like projects) concurrently with their child elements (like user lists) using `Promise.all`.
+
+## 2024-05-19 - [In-memory derivation of subset collections]
+**Learning:** Fetching a global collection (e.g., all lists) and a subset of that collection (e.g., project lists) simultaneously on the frontend leads to redundant backend queries.
+**Action:** When both a full collection and a subset are required concurrently, fetch the full collection and derive the subset in-memory via filtering. This prevents duplicate API requests and unnecessary backend database queries.

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -58,17 +58,16 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setIsLoading(true);
 
       // OPTIMIZATION: Execute independent network requests and JSON parsing concurrently
-      // using Promise.all. This prevents a 3-step waterfall, reducing Time to First Byte
-      // (TTFB) and overall load time significantly on this detail page.
-      const [projectRes, listsRes, allListsRes] = await Promise.all([
+      // using Promise.all. This prevents a waterfall.
+      // Furthermore, instead of making a redundant API request to fetch project lists,
+      // derive the subset in-memory from all lists to avoid duplicate backend database queries.
+      const [projectRes, allListsRes] = await Promise.all([
         fetch(`/api/projects/${projectId}`),
-        fetch(`/api/projects/${projectId}/lists`),
         fetch("/api/lists"),
       ]);
 
-      const [projectResult, listsResult, allListsResult] = await Promise.all([
+      const [projectResult, allListsResult] = await Promise.all([
         projectRes.json(),
-        listsRes.json(),
         allListsRes.json(),
       ]);
 
@@ -81,12 +80,10 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setEditName(projectResult.data.name);
       setEditDescription(projectResult.data.description || "");
 
-      if (listsResult.success) {
-        setLists(listsResult.data);
-      }
-
       if (allListsResult.success) {
-        setAllLists(allListsResult.data);
+        const fetchedAllLists = allListsResult.data as List[];
+        setAllLists(fetchedAllLists);
+        setLists(fetchedAllLists.filter((list) => list.projectId === projectId));
       }
     } catch (err) {
       console.error("Error fetching project:", err);


### PR DESCRIPTION
💡 What:
Removed the redundant `fetch('/api/projects/${projectId}/lists')` network request in `src/app/projects/[id]/page.tsx` and instead derived the project-specific lists in-memory by filtering the globally fetched `allLists` response.

🎯 Why:
The frontend was simultaneously fetching a global collection (all user lists via `/api/lists`) and a subset of that collection (project-specific lists via `/api/projects/[id]/lists`) using `Promise.all`. This resulted in a redundant API request and duplicate backend query.

📊 Impact:
- Reduces the number of outgoing HTTP requests on the project detail page from 3 to 2.
- Eliminates a redundant database query (fetching user lists and filtering by project, which `/api/lists` already retrieves).
- Decreases load time and server resource consumption slightly by relying on in-memory JavaScript array filtering.

🔬 Measurement:
1. Load a project detail page (e.g., `/projects/[id]`).
2. Observe the Network tab in DevTools.
3. Verify that `/api/lists` is called, but `/api/projects/[id]/lists` is no longer called, while all lists still render correctly under the project.

---
*PR created automatically by Jules for task [362642379296486606](https://jules.google.com/task/362642379296486606) started by @aicoder2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new documentation describing efficient data-fetching patterns for concurrent data needs.

* **Refactor**
  * Improved performance on project detail pages by optimizing how lists are fetched and processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->