### PR TITLE
⚡ Bolt: Derive project lists in-memory

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Concurrent Fetching with Owner IDs in Share Links
 **Learning:** In the share system, endpoints processing a share code typically suffer from waterfall latency by first loading target entity details (like a project) and then querying its associated elements (like project lists) using the entity's owner ID (`userId`). However, the `shareLink` object already contains the `userId` field (representing the owner's ID).
 **Action:** Always leverage the existing owner's ID within `shareLink` to bypass sequential dependencies and fetch parent entities (like projects) concurrently with their child elements (like user lists) using `Promise.all`.
+
+## 2024-06-11 - Derive Subset Collections In-Memory
+**Learning:** When fetching both a global collection (e.g., all lists for a user) and a subset of that collection (e.g., lists for a specific project) concurrently, fetching both from the backend causes duplicate database queries.
+**Action:** Instead of making two separate network/API requests, fetch only the global collection and derive the subset in-memory using array filtering (e.g., `globalLists.filter(...)`) to reduce redundant backend operations and improve overall rendering performance.

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -57,18 +57,15 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
     try {
       setIsLoading(true);
 
-      // OPTIMIZATION: Execute independent network requests and JSON parsing concurrently
-      // using Promise.all. This prevents a 3-step waterfall, reducing Time to First Byte
-      // (TTFB) and overall load time significantly on this detail page.
-      const [projectRes, listsRes, allListsRes] = await Promise.all([
+      // OPTIMIZATION: Execute independent network requests concurrently
+      // using Promise.all.
+      const [projectRes, allListsRes] = await Promise.all([
         fetch(`/api/projects/${projectId}`),
-        fetch(`/api/projects/${projectId}/lists`),
         fetch("/api/lists"),
       ]);
 
-      const [projectResult, listsResult, allListsResult] = await Promise.all([
+      const [projectResult, allListsResult] = await Promise.all([
         projectRes.json(),
-        listsRes.json(),
         allListsRes.json(),
       ]);
 
@@ -81,12 +78,14 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setEditName(projectResult.data.name);
       setEditDescription(projectResult.data.description || "");
 
-      if (listsResult.success) {
-        setLists(listsResult.data);
-      }
-
       if (allListsResult.success) {
-        setAllLists(allListsResult.data);
+        const globalLists = allListsResult.data as List[];
+        setAllLists(globalLists);
+
+        // OPTIMIZATION: Derive subset in-memory instead of redundant network fetch
+        // Filtering the global list avoids duplicate backend database queries.
+        const projectLists = globalLists.filter(list => list.projectId === projectId);
+        setLists(projectLists);
       }
     } catch (err) {
       console.error("Error fetching project:", err);


### PR DESCRIPTION
### 💡 What
Modified the project detail page (`src/app/projects/[id]/page.tsx`) to derive the project's lists in-memory instead of making a redundant API request to `/api/projects/[id]/lists`.

### 🎯 Why
When navigating to a project detail page, the application was concurrently fetching both all user lists (`/api/lists`) and the lists specifically for the current project (`/api/projects/[id]/lists`). Since the project lists are a strict subset of all user lists, fetching both concurrently resulted in duplicate backend database queries and unnecessary network load.

### 📊 Impact
Reduces backend database load and network traffic for the project detail page by eliminating one redundant API call. Saves overhead on JSON parsing and network latency for that specific request.

### 🔬 Measurement
Run the application and monitor the network tab when navigating to a project detail page. Observe that the `/api/projects/[id]/lists` request is no longer made, while the UI still correctly populates the project lists table. Tests have also been successfully run to confirm logic correctness.

---
*PR created automatically by Jules for task [1321901733549684601](https://jules.google.com/task/1321901733549684601) started by @aicoder2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added optimization guide for fetching global collections and deriving subsets locally.

* **Performance Improvements**
  * Reduced network calls when loading project details by consolidating list data fetching and filtering locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->