### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in bulk lookup

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** The application was using the `marked` library to parse Markdown content into HTML (in `src/app/docs/changelog/page.tsx` and `src/lib/docs.ts`) and subsequently rendering it using `dangerouslySetInnerHTML` without proper sanitization.
 **Learning:** `marked` does not sanitize HTML by default. While this may seem safe for trusted inputs (like internal docs or GitHub releases), if malicious input manages to enter these sources, it leads directly to an XSS vulnerability.
 **Prevention:** The output of `marked` (or any markdown parser) must always be wrapped with `DOMPurify.sanitize()` (using `isomorphic-dompurify` for SSR) before being passed to `dangerouslySetInnerHTML`.
+
+## 2024-06-12 - Prevent SSRF in Next.js API Routes via loopback fetch
+**Vulnerability:** The bulk lookup endpoint (`/api/lookup/bulk`) used `fetch(request.nextUrl.origin + '/api/...')` to invoke other API endpoints. Because `request.nextUrl.origin` is derived from the user-controlled `Host` header, an attacker could spoof the header, causing the server to make requests to arbitrary external or internal domains (SSRF).
+**Learning:** Relying on loopback HTTP fetch requests within a single server application for internal communication introduces unnecessary network overhead and SSRF vulnerability risks, particularly when routing dynamically based on request headers.
+**Prevention:** Rather than using HTTP loopbacks, import and invoke the internal Next.js Route Handler functions directly. To ensure correct processing by the route handler, explicitly construct and pass a synthetic `NextRequest` object instead of simple JSON or standard HTTP request constructs.

--- a/src/app/api/lookup/bulk/route.test.ts
+++ b/src/app/api/lookup/bulk/route.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from './route';
 import { NextRequest } from 'next/server';
 
-global.fetch = vi.fn();
+import { POST as urlHandler } from '../url/route';
+import { POST as doiHandler } from '../doi/route';
+import { POST as isbnHandler } from '../isbn/route';
+
+vi.mock('../url/route', () => ({ POST: vi.fn() }));
+vi.mock('../doi/route', () => ({ POST: vi.fn() }));
+vi.mock('../isbn/route', () => ({ POST: vi.fn() }));
 
 function makeRequest(body: object) {
   return new NextRequest('http://localhost/api/lookup/bulk', {
@@ -54,7 +60,7 @@ describe('Bulk Lookup API', () => {
   });
 
   it('routes URLs to /api/lookup/url', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    (urlHandler as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
       json: async () => ({ data: { title: 'Example Page' } }),
     });
@@ -62,36 +68,36 @@ describe('Bulk Lookup API', () => {
     const data = await response.json();
     expect(data.results[0].success).toBe(true);
     expect(data.results[0].data.title).toBe('Example Page');
-    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
-    expect(url).toContain('/api/lookup/url');
+    const [req] = (urlHandler as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(req.url).toContain('/api/lookup/url');
   });
 
   it('routes DOIs to /api/lookup/doi', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    (doiHandler as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
       json: async () => ({ data: { title: 'Research Article' } }),
     });
     const response = await POST(makeRequest({ items: ['10.1000/xyz123'] }));
     const data = await response.json();
     expect(data.results[0].success).toBe(true);
-    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
-    expect(url).toContain('/api/lookup/doi');
+    const [req] = (doiHandler as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(req.url).toContain('/api/lookup/doi');
   });
 
   it('routes ISBNs to /api/lookup/isbn', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    (isbnHandler as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
       json: async () => ({ data: { title: 'Book Title' } }),
     });
     const response = await POST(makeRequest({ items: ['9780316769174'] }));
     const data = await response.json();
     expect(data.results[0].success).toBe(true);
-    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
-    expect(url).toContain('/api/lookup/isbn');
+    const [req] = (isbnHandler as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(req.url).toContain('/api/lookup/isbn');
   });
 
   it('marks item as failed when sub-request fails', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    (doiHandler as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: false,
       json: async () => ({ error: 'Not found' }),
     });
@@ -102,9 +108,8 @@ describe('Bulk Lookup API', () => {
   });
 
   it('returns summary counts', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'A' } }) })
-      .mockResolvedValueOnce({ ok: false, json: async () => ({ error: 'fail' }) });
+    (urlHandler as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'A' } }) });
+    (doiHandler as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: false, json: async () => ({ error: 'fail' }) });
     const response = await POST(
       makeRequest({ items: ['https://success.com', '10.1000/fail'] })
     );
@@ -115,9 +120,8 @@ describe('Bulk Lookup API', () => {
   });
 
   it('handles mixed item types in one batch', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'URL result' } }) })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'DOI result' } }) });
+    (urlHandler as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'URL result' } }) });
+    (doiHandler as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'DOI result' } }) });
     const response = await POST(
       makeRequest({ items: ['https://example.com', '10.1000/abc'] })
     );

--- a/src/app/api/lookup/bulk/route.ts
+++ b/src/app/api/lookup/bulk/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import { POST as urlHandler } from "../url/route";
+import { POST as doiHandler } from "../doi/route";
+import { POST as isbnHandler } from "../isbn/route";
+
 
 interface LookupResult {
   input: string;
@@ -22,8 +26,6 @@ export async function POST(request: NextRequest) {
     }
 
     // Refactored to process lookups concurrently for performance improvement
-    const baseUrl = request.nextUrl.origin;
-
     const lookupPromises = items.map(async (item) => {
       const trimmedItem = item.trim();
       if (!trimmedItem) {
@@ -31,18 +33,22 @@ export async function POST(request: NextRequest) {
       }
 
       try {
-        let apiEndpoint: string;
         let body: object;
-
         // Detect input type
+        let handler: (req: NextRequest) => Promise<NextResponse>;
+        let handlerUrl: string;
+
         if (trimmedItem.match(/^(https?:\/\/|www\.)/i)) {
-          apiEndpoint = "/api/lookup/url";
+          handler = urlHandler;
+          handlerUrl = "http://localhost/api/lookup/url";
           body = { url: trimmedItem };
         } else if (trimmedItem.match(/^10\.\d{4,}/)) {
-          apiEndpoint = "/api/lookup/doi";
+          handler = doiHandler;
+          handlerUrl = "http://localhost/api/lookup/doi";
           body = { doi: trimmedItem };
         } else if (trimmedItem.match(/^(97[89])?\d{9}[\dXx]$/)) {
-          apiEndpoint = "/api/lookup/isbn";
+          handler = isbnHandler;
+          handlerUrl = "http://localhost/api/lookup/isbn";
           body = { isbn: trimmedItem };
         } else {
           return {
@@ -52,12 +58,14 @@ export async function POST(request: NextRequest) {
           };
         }
 
-        // Make the API call
-        const response = await fetch(`${baseUrl}${apiEndpoint}`, {
+        const syntheticRequest = new NextRequest(new URL(handlerUrl), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),
         });
+
+        // Make the API call
+        const response = await handler(syntheticRequest);
 
         const data = await response.json();
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `/api/lookup/bulk` endpoint used `request.nextUrl.origin` to determine the base URL for internal API calls via `fetch()`. Because this origin is derived from the `Host` header, it could be spoofed by an attacker, leading to Server-Side Request Forgery (SSRF) and allowing the server to proxy requests to arbitrary external or internal network locations.
🎯 Impact: Attackers could abuse the bulk lookup proxy to scan internal networks, access private resources, or bypass external IP-based protections.
🔧 Fix: Replaced network-based internal `fetch` loopbacks with direct function invocations. The handlers for `/api/lookup/url`, `/api/lookup/doi`, and `/api/lookup/isbn` are now imported and called directly with a synthetically constructed `NextRequest`.
✅ Verification: `pnpm lint` and `pnpm test:run` pass. The tests for `src/app/api/lookup/bulk/route.test.ts` were updated to mock the internal handlers and confirm the direct invocation logic.

---
*PR created automatically by Jules for task [15995001700895303358](https://jules.google.com/task/15995001700895303358) started by @aicoder2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed a Server-Side Request Forgery (SSRF) vulnerability in the bulk lookup API endpoint. The implementation has been updated to eliminate this vulnerability. All existing functionality remains intact, and the changes are fully backward compatible with no action required from end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->