### PR TITLE
⚡ Bolt: Remove redundant project lists API call

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Concurrent Fetching with Owner IDs in Share Links
 **Learning:** In the share system, endpoints processing a share code typically suffer from waterfall latency by first loading target entity details (like a project) and then querying its associated elements (like project lists) using the entity's owner ID (`userId`). However, the `shareLink` object already contains the `userId` field (representing the owner's ID).
 **Action:** Always leverage the existing owner's ID within `shareLink` to bypass sequential dependencies and fetch parent entities (like projects) concurrently with their child elements (like user lists) using `Promise.all`.
+
+## 2024-05-19 - [Avoid Redundant Subset Fetching]
+**Learning:** When fetching a global collection (e.g., all lists for a user) alongside a subset of that collection (e.g., lists associated with a specific project) on the same page, performing two separate API calls is redundant and increases backend load needlessly.
+**Action:** Always fetch the global collection via the API and then derive the subset in-memory using array filtering. This eliminates duplicate queries to the database while keeping the UI responsive.

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -58,17 +58,19 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setIsLoading(true);
 
       // OPTIMIZATION: Execute independent network requests and JSON parsing concurrently
-      // using Promise.all. This prevents a 3-step waterfall, reducing Time to First Byte
+      // using Promise.all. This prevents a waterfall, reducing Time to First Byte
       // (TTFB) and overall load time significantly on this detail page.
-      const [projectRes, listsRes, allListsRes] = await Promise.all([
+      //
+      // We also fetch all lists to allow adding existing lists. Instead of a
+      // redundant third API call to `/api/projects/[id]/lists`, we derive
+      // the project lists via in-memory filtering.
+      const [projectRes, allListsRes] = await Promise.all([
         fetch(`/api/projects/${projectId}`),
-        fetch(`/api/projects/${projectId}/lists`),
         fetch("/api/lists"),
       ]);
 
-      const [projectResult, listsResult, allListsResult] = await Promise.all([
+      const [projectResult, allListsResult] = await Promise.all([
         projectRes.json(),
-        listsRes.json(),
         allListsRes.json(),
       ]);
 
@@ -81,12 +83,9 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setEditName(projectResult.data.name);
       setEditDescription(projectResult.data.description || "");
 
-      if (listsResult.success) {
-        setLists(listsResult.data);
-      }
-
       if (allListsResult.success) {
         setAllLists(allListsResult.data);
+        setLists(allListsResult.data.filter((l: List) => l.projectId === projectId));
       }
     } catch (err) {
       console.error("Error fetching project:", err);


### PR DESCRIPTION
**💡 What:**
Removed a redundant `fetch('/api/projects/${projectId}/lists')` call in the `src/app/projects/[id]/page.tsx` component. Instead of making two API calls for lists, the component now fetches all user lists via `/api/lists` and derives the `projectLists` in-memory by filtering the result.

**🎯 Why:**
Making two separate API calls to retrieve list data was an unnecessary redundancy. The front-end was fetching all lists and all project-specific lists when the latter was simply a subset of the former. This resulted in unnecessary load on the backend database and network overhead.

**📊 Impact:**
Eliminates one unnecessary network request per project page load. This reduces Time to First Byte (TTFB), improves frontend responsiveness, and decreases overall database reads significantly.

**🔬 Measurement:**
This optimization can be verified by observing network requests in browser developer tools or the server logs when navigating to a project detail page. There should only be two parallel fetch calls (`/api/projects/[id]` and `/api/lists`), down from three previously.

---
*PR created automatically by Jules for task [2594485108370885755](https://jules.google.com/task/2594485108370885755) started by @aicoder2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added development guideline on best practices for efficient data-fetching patterns to minimize unnecessary API requests.

* **Refactor**
  * Optimized project data loading by eliminating redundant API calls and consolidating data retrieval operations, resulting in improved application responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->