### PR TITLE
⚡ Bolt: [frontend optimization] Derive project lists in-memory

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Concurrent Fetching with Owner IDs in Share Links
 **Learning:** In the share system, endpoints processing a share code typically suffer from waterfall latency by first loading target entity details (like a project) and then querying its associated elements (like project lists) using the entity's owner ID (`userId`). However, the `shareLink` object already contains the `userId` field (representing the owner's ID).
 **Action:** Always leverage the existing owner's ID within `shareLink` to bypass sequential dependencies and fetch parent entities (like projects) concurrently with their child elements (like user lists) using `Promise.all`.
+
+## 2024-05-19 - Derive Subset Queries In-Memory
+**Learning:** When a page needs to fetch both a global collection (like all user lists) and a specific subset of that collection (like lists belonging to a specific project), making two separate API requests (even concurrently) results in redundant backend database queries.
+**Action:** Instead of querying the backend twice, fetch only the global collection and derive the specific subset in-memory on the frontend using array filtering (e.g., `allLists.filter(list => list.projectId === projectId)`). This avoids duplicate database load.

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -58,17 +58,16 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setIsLoading(true);
 
       // OPTIMIZATION: Execute independent network requests and JSON parsing concurrently
-      // using Promise.all. This prevents a 3-step waterfall, reducing Time to First Byte
-      // (TTFB) and overall load time significantly on this detail page.
-      const [projectRes, listsRes, allListsRes] = await Promise.all([
+      // using Promise.all. This prevents a waterfall, reducing Time to First Byte (TTFB).
+      // We also derive project-specific lists in-memory from the "all lists" request
+      // to avoid a redundant duplicate backend query.
+      const [projectRes, allListsRes] = await Promise.all([
         fetch(`/api/projects/${projectId}`),
-        fetch(`/api/projects/${projectId}/lists`),
         fetch("/api/lists"),
       ]);
 
-      const [projectResult, listsResult, allListsResult] = await Promise.all([
+      const [projectResult, allListsResult] = await Promise.all([
         projectRes.json(),
-        listsRes.json(),
         allListsRes.json(),
       ]);
 
@@ -81,12 +80,10 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setEditName(projectResult.data.name);
       setEditDescription(projectResult.data.description || "");
 
-      if (listsResult.success) {
-        setLists(listsResult.data);
-      }
-
       if (allListsResult.success) {
         setAllLists(allListsResult.data);
+        const projectLists = allListsResult.data.filter((list: List) => list.projectId === projectId);
+        setLists(projectLists);
       }
     } catch (err) {
       console.error("Error fetching project:", err);


### PR DESCRIPTION
💡 What: Removes the redundant API call to `/api/projects/${projectId}/lists` in `src/app/projects/[id]/page.tsx` and derives the specific project's lists in-memory by filtering the result from `/api/lists`.

🎯 Why: The page was previously fetching both all lists for the user AND the specific project's lists concurrently. Because the project's lists are just a subset of all lists, making a second request to the backend results in a redundant database query and network overhead.

📊 Impact: Reduces the number of API requests on the project detail page from 3 to 2, directly eliminating one backend database query and slightly improving the frontend load time by reducing browser networking overhead.

🔬 Measurement: Verify by loading the project detail page (`/projects/[id]`) and observing the network tab; the request to `/api/projects/[id]/lists` should be absent while the list of citations continues to load correctly. Run `pnpm test` to ensure no regressions.

---
*PR created automatically by Jules for task [9298628635097187769](https://jules.google.com/task/9298628635097187769) started by @aicoder2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized data fetching to reduce the number of backend requests and improve page load times.

* **Documentation**
  * Added guidance on deriving subset data in-memory for efficient query handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->