### PR TITLE
⚡ Bolt: [performance improvement] In-memory subset filtering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Concurrent Fetching with Owner IDs in Share Links
 **Learning:** In the share system, endpoints processing a share code typically suffer from waterfall latency by first loading target entity details (like a project) and then querying its associated elements (like project lists) using the entity's owner ID (`userId`). However, the `shareLink` object already contains the `userId` field (representing the owner's ID).
 **Action:** Always leverage the existing owner's ID within `shareLink` to bypass sequential dependencies and fetch parent entities (like projects) concurrently with their child elements (like user lists) using `Promise.all`.
+
+## 2024-05-19 - In-memory subset filtering
+**Learning:** Making simultaneous, parallel API requests for both a global collection (like all user lists) and a specific subset of that collection (like lists for a specific project) is an anti-pattern that creates unnecessary backend queries and network overhead.
+**Action:** When both a complete collection and a filtered subset are required by the UI, always fetch only the full collection and derive the subset in-memory using array filtering.

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -60,15 +60,13 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       // OPTIMIZATION: Execute independent network requests and JSON parsing concurrently
       // using Promise.all. This prevents a 3-step waterfall, reducing Time to First Byte
       // (TTFB) and overall load time significantly on this detail page.
-      const [projectRes, listsRes, allListsRes] = await Promise.all([
+      const [projectRes, allListsRes] = await Promise.all([
         fetch(`/api/projects/${projectId}`),
-        fetch(`/api/projects/${projectId}/lists`),
         fetch("/api/lists"),
       ]);
 
-      const [projectResult, listsResult, allListsResult] = await Promise.all([
+      const [projectResult, allListsResult] = await Promise.all([
         projectRes.json(),
-        listsRes.json(),
         allListsRes.json(),
       ]);
 
@@ -81,12 +79,11 @@ export default function ProjectDetailPage({ params }: { params: Promise<{ id: st
       setEditName(projectResult.data.name);
       setEditDescription(projectResult.data.description || "");
 
-      if (listsResult.success) {
-        setLists(listsResult.data);
-      }
-
       if (allListsResult.success) {
         setAllLists(allListsResult.data);
+        // OPTIMIZATION: Derive project lists in-memory to save a redundant network request
+        const projectLists = allListsResult.data.filter((list: List) => list.projectId === projectId);
+        setLists(projectLists);
       }
     } catch (err) {
       console.error("Error fetching project:", err);


### PR DESCRIPTION
💡 **What**: Removed a redundant API call to `/api/projects/[id]/lists` in the project detail page and instead derived the project-specific lists by filtering the results from the global `/api/lists` query.

🎯 **Why**: The frontend was making a redundant network request. It was querying the backend for "all user lists" while simultaneously querying the backend for "lists for this specific project". This created unnecessary backend load and network overhead.

📊 **Impact**: Saves 1 complete HTTP request/response cycle on every load of the project detail page, reducing Time to First Byte (TTFB), database queries, and bandwidth.

🔬 **Measurement**: Observe the Network tab in DevTools when loading `/projects/[id]`. You will now see 2 concurrent requests (`/api/projects/[id]` and `/api/lists`) instead of 3. The UI continues to render correctly.

---
*PR created automatically by Jules for task [4437197563075260895](https://jules.google.com/task/4437197563075260895) started by @aicoder2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on efficiently handling filtered data subsets by deriving them in-memory.

* **Performance**
  * Optimized project data loading by reducing the number of network requests and deriving filtered results more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->