### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Host-header SSRF in bulk lookup API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** The application was using the `marked` library to parse Markdown content into HTML (in `src/app/docs/changelog/page.tsx` and `src/lib/docs.ts`) and subsequently rendering it using `dangerouslySetInnerHTML` without proper sanitization.
 **Learning:** `marked` does not sanitize HTML by default. While this may seem safe for trusted inputs (like internal docs or GitHub releases), if malicious input manages to enter these sources, it leads directly to an XSS vulnerability.
 **Prevention:** The output of `marked` (or any markdown parser) must always be wrapped with `DOMPurify.sanitize()` (using `isomorphic-dompurify` for SSR) before being passed to `dangerouslySetInnerHTML`.
+
+## 2024-06-15 - Host-header SSRF via loopback fetch
+**Vulnerability:** The bulk lookup API (`/api/lookup/bulk/route.ts`) used `request.nextUrl.origin` to construct loopback URLs for fetching individual metadata via `fetch()`. Because `request.nextUrl.origin` is derived from the user-controlled `Host` header, an attacker could spoof the `Host` header to route the `fetch` request to an internal private IP or internal metadata endpoints, bypassing typical SSRF safeguards on direct URL inputs.
+**Learning:** Never rely on user-controlled headers (like `Host`) to build URLs for internal server-side `fetch` requests. Loopback calls via HTTP are intrinsically dangerous in this scenario.
+**Prevention:** Instead of using HTTP loopback `fetch()`, dynamically import and directly invoke internal Next.js Route Handler functions (e.g., the `POST` method of a sibling route) by creating and passing a synthetic `NextRequest` object.

--- a/src/app/api/lookup/bulk/route.test.ts
+++ b/src/app/api/lookup/bulk/route.test.ts
@@ -1,8 +1,28 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from './route';
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
-global.fetch = vi.fn();
+const mockUrlPost = vi.fn();
+const mockDoiPost = vi.fn();
+const mockIsbnPost = vi.fn();
+
+vi.mock('../url/route', () => ({
+  get POST() {
+    return mockUrlPost;
+  }
+}));
+
+vi.mock('../doi/route', () => ({
+  get POST() {
+    return mockDoiPost;
+  }
+}));
+
+vi.mock('../isbn/route', () => ({
+  get POST() {
+    return mockIsbnPost;
+  }
+}));
 
 function makeRequest(body: object) {
   return new NextRequest('http://localhost/api/lookup/bulk', {
@@ -14,6 +34,9 @@ function makeRequest(body: object) {
 describe('Bulk Lookup API', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUrlPost.mockReset();
+    mockDoiPost.mockReset();
+    mockIsbnPost.mockReset();
   });
 
   it('returns 400 when items is missing', async () => {
@@ -54,47 +77,40 @@ describe('Bulk Lookup API', () => {
   });
 
   it('routes URLs to /api/lookup/url', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ data: { title: 'Example Page' } }),
-    });
+    mockUrlPost.mockResolvedValueOnce(
+      NextResponse.json({ data: { title: 'Example Page' } })
+    );
     const response = await POST(makeRequest({ items: ['https://example.com'] }));
     const data = await response.json();
     expect(data.results[0].success).toBe(true);
     expect(data.results[0].data.title).toBe('Example Page');
-    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
-    expect(url).toContain('/api/lookup/url');
+    expect(mockUrlPost).toHaveBeenCalled();
   });
 
   it('routes DOIs to /api/lookup/doi', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ data: { title: 'Research Article' } }),
-    });
+    mockDoiPost.mockResolvedValueOnce(
+      NextResponse.json({ data: { title: 'Research Article' } })
+    );
     const response = await POST(makeRequest({ items: ['10.1000/xyz123'] }));
     const data = await response.json();
     expect(data.results[0].success).toBe(true);
-    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
-    expect(url).toContain('/api/lookup/doi');
+    expect(mockDoiPost).toHaveBeenCalled();
   });
 
   it('routes ISBNs to /api/lookup/isbn', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ data: { title: 'Book Title' } }),
-    });
+    mockIsbnPost.mockResolvedValueOnce(
+      NextResponse.json({ data: { title: 'Book Title' } })
+    );
     const response = await POST(makeRequest({ items: ['9780316769174'] }));
     const data = await response.json();
     expect(data.results[0].success).toBe(true);
-    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
-    expect(url).toContain('/api/lookup/isbn');
+    expect(mockIsbnPost).toHaveBeenCalled();
   });
 
   it('marks item as failed when sub-request fails', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ error: 'Not found' }),
-    });
+    mockDoiPost.mockResolvedValueOnce(
+      NextResponse.json({ error: 'Not found' }, { status: 404 })
+    );
     const response = await POST(makeRequest({ items: ['10.1000/nonexistent'] }));
     const data = await response.json();
     expect(data.results[0].success).toBe(false);
@@ -102,9 +118,9 @@ describe('Bulk Lookup API', () => {
   });
 
   it('returns summary counts', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'A' } }) })
-      .mockResolvedValueOnce({ ok: false, json: async () => ({ error: 'fail' }) });
+    mockUrlPost.mockResolvedValueOnce(NextResponse.json({ data: { title: 'A' } }));
+    mockDoiPost.mockResolvedValueOnce(NextResponse.json({ error: 'fail' }, { status: 500 }));
+
     const response = await POST(
       makeRequest({ items: ['https://success.com', '10.1000/fail'] })
     );
@@ -115,15 +131,16 @@ describe('Bulk Lookup API', () => {
   });
 
   it('handles mixed item types in one batch', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'URL result' } }) })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'DOI result' } }) });
+    mockUrlPost.mockResolvedValueOnce(NextResponse.json({ data: { title: 'URL result' } }));
+    mockDoiPost.mockResolvedValueOnce(NextResponse.json({ data: { title: 'DOI result' } }));
+
     const response = await POST(
       makeRequest({ items: ['https://example.com', '10.1000/abc'] })
     );
     const data = await response.json();
     expect(data.summary.success).toBe(2);
-    expect(data.results[0].data.title).toBe('URL result');
-    expect(data.results[1].data.title).toBe('DOI result');
+    // results might return in different order depending on resolving, but for testing map order is preserved
+    expect(data.results.find((r: any) => r.input === 'https://example.com')?.data?.title).toBe('URL result');
+    expect(data.results.find((r: any) => r.input === '10.1000/abc')?.data?.title).toBe('DOI result');
   });
 });

--- a/src/app/api/lookup/bulk/route.ts
+++ b/src/app/api/lookup/bulk/route.ts
@@ -22,7 +22,6 @@ export async function POST(request: NextRequest) {
     }
 
     // Refactored to process lookups concurrently for performance improvement
-    const baseUrl = request.nextUrl.origin;
 
     const lookupPromises = items.map(async (item) => {
       const trimmedItem = item.trim();
@@ -31,19 +30,22 @@ export async function POST(request: NextRequest) {
       }
 
       try {
-        let apiEndpoint: string;
-        let body: object;
+        let handler: (req: NextRequest) => Promise<NextResponse> | NextResponse;
+        let reqBody: object;
 
         // Detect input type
         if (trimmedItem.match(/^(https?:\/\/|www\.)/i)) {
-          apiEndpoint = "/api/lookup/url";
-          body = { url: trimmedItem };
+          const { POST } = await import("../url/route");
+          handler = POST;
+          reqBody = { url: trimmedItem };
         } else if (trimmedItem.match(/^10\.\d{4,}/)) {
-          apiEndpoint = "/api/lookup/doi";
-          body = { doi: trimmedItem };
+          const { POST } = await import("../doi/route");
+          handler = POST;
+          reqBody = { doi: trimmedItem };
         } else if (trimmedItem.match(/^(97[89])?\d{9}[\dXx]$/)) {
-          apiEndpoint = "/api/lookup/isbn";
-          body = { isbn: trimmedItem };
+          const { POST } = await import("../isbn/route");
+          handler = POST;
+          reqBody = { isbn: trimmedItem };
         } else {
           return {
             input: trimmedItem,
@@ -52,13 +54,15 @@ export async function POST(request: NextRequest) {
           };
         }
 
-        // Make the API call
-        const response = await fetch(`${baseUrl}${apiEndpoint}`, {
+        // Invoke the route handler directly to prevent Host-header SSRF.
+        // We create a synthetic NextRequest to mimic an inbound API call.
+        const syntheticRequest = new NextRequest(new URL("http://localhost"), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(body),
+          body: JSON.stringify(reqBody),
         });
 
+        const response = await handler(syntheticRequest);
         const data = await response.json();
 
         if (response.ok && data.data) {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Host-header SSRF via Server-Side HTTP Loopback Fetch
🎯 **Impact:** An attacker could supply a malicious `Host` header to route the Next.js API loopback `fetch` request (`request.nextUrl.origin`) to an internal private IP or sensitive backend service.
🔧 **Fix:** Replaced loopback `fetch()` calls with dynamically imported and directly invoked sibling route handlers (`POST`). Passed a synthetic `NextRequest` to mimic the inbound API call, bypassing the vulnerable network layer entirely.
✅ **Verification:** Validated that internal fetch calls are gone and tested via the updated vitest suite (`pnpm test:run`) to ensure metadata lookup routing and concurrency behave properly.

---
*PR created automatically by Jules for task [1291081681246977337](https://jules.google.com/task/1291081681246977337) started by @aicoder2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Server-Side Request Forgery (SSRF) vulnerability in the bulk lookup API that could be exploited via the Host header.

* **Tests**
  * Updated test suite to align with internal implementation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->