### PR TITLE
🛡️ Sentinel: [HIGH] Fix Host-Header SSRF in Bulk Lookup

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** The application was using the `marked` library to parse Markdown content into HTML (in `src/app/docs/changelog/page.tsx` and `src/lib/docs.ts`) and subsequently rendering it using `dangerouslySetInnerHTML` without proper sanitization.
 **Learning:** `marked` does not sanitize HTML by default. While this may seem safe for trusted inputs (like internal docs or GitHub releases), if malicious input manages to enter these sources, it leads directly to an XSS vulnerability.
 **Prevention:** The output of `marked` (or any markdown parser) must always be wrapped with `DOMPurify.sanitize()` (using `isomorphic-dompurify` for SSR) before being passed to `dangerouslySetInnerHTML`.
+
+## 2025-06-16 - Host-Header SSRF in Loopback Fetch
+**Vulnerability:** The bulk lookup API (`src/app/api/lookup/bulk/route.ts`) was performing loopback HTTP requests to other internal route handlers (e.g., `/api/lookup/url`) using `fetch(\`\${request.nextUrl.origin}\${apiEndpoint}\`)`. Because `request.nextUrl.origin` is derived from the user-controllable `Host` header, an attacker could spoof the `Host` header to cause the server to make requests to arbitrary external domains (Server-Side Request Forgery).
+**Learning:** In Next.js, making HTTP requests to internal API routes using `fetch()` with dynamically derived origins creates an SSRF vector if the origin relies on the `Host` header. It also introduces unnecessary network overhead.
+**Prevention:** Avoid loopback `fetch` calls. Instead, import the route handler functions directly (e.g., `import { POST } from '../url/route'`) and invoke them directly using a synthetic `NextRequest` object (`new NextRequest(new URL('http://localhost'), ...)`).

--- a/src/app/api/lookup/bulk/route.test.ts
+++ b/src/app/api/lookup/bulk/route.test.ts
@@ -2,7 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from './route';
 import { NextRequest } from 'next/server';
 
-global.fetch = vi.fn();
+vi.mock('../url/route', () => ({ POST: vi.fn() }));
+vi.mock('../doi/route', () => ({ POST: vi.fn() }));
+vi.mock('../isbn/route', () => ({ POST: vi.fn() }));
+
+import { POST as urlPost } from '../url/route';
+import { POST as doiPost } from '../doi/route';
+import { POST as isbnPost } from '../isbn/route';
+
+
 
 function makeRequest(body: object) {
   return new NextRequest('http://localhost/api/lookup/bulk', {
@@ -54,7 +62,7 @@ describe('Bulk Lookup API', () => {
   });
 
   it('routes URLs to /api/lookup/url', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    (urlPost as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
       json: async () => ({ data: { title: 'Example Page' } }),
     });
@@ -62,36 +70,33 @@ describe('Bulk Lookup API', () => {
     const data = await response.json();
     expect(data.results[0].success).toBe(true);
     expect(data.results[0].data.title).toBe('Example Page');
-    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
-    expect(url).toContain('/api/lookup/url');
+    expect(urlPost).toHaveBeenCalled();
   });
 
   it('routes DOIs to /api/lookup/doi', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    (doiPost as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
       json: async () => ({ data: { title: 'Research Article' } }),
     });
     const response = await POST(makeRequest({ items: ['10.1000/xyz123'] }));
     const data = await response.json();
     expect(data.results[0].success).toBe(true);
-    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
-    expect(url).toContain('/api/lookup/doi');
+    expect(doiPost).toHaveBeenCalled();
   });
 
   it('routes ISBNs to /api/lookup/isbn', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    (isbnPost as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
       json: async () => ({ data: { title: 'Book Title' } }),
     });
     const response = await POST(makeRequest({ items: ['9780316769174'] }));
     const data = await response.json();
     expect(data.results[0].success).toBe(true);
-    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
-    expect(url).toContain('/api/lookup/isbn');
+    expect(isbnPost).toHaveBeenCalled();
   });
 
   it('marks item as failed when sub-request fails', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    (doiPost as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: false,
       json: async () => ({ error: 'Not found' }),
     });
@@ -102,9 +107,8 @@ describe('Bulk Lookup API', () => {
   });
 
   it('returns summary counts', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'A' } }) })
-      .mockResolvedValueOnce({ ok: false, json: async () => ({ error: 'fail' }) });
+    (urlPost as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'A' } }) });
+    (doiPost as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: false, json: async () => ({ error: 'fail' }) });
     const response = await POST(
       makeRequest({ items: ['https://success.com', '10.1000/fail'] })
     );
@@ -115,9 +119,8 @@ describe('Bulk Lookup API', () => {
   });
 
   it('handles mixed item types in one batch', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'URL result' } }) })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'DOI result' } }) });
+    (urlPost as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'URL result' } }) });
+    (doiPost as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: true, json: async () => ({ data: { title: 'DOI result' } }) });
     const response = await POST(
       makeRequest({ items: ['https://example.com', '10.1000/abc'] })
     );

--- a/src/app/api/lookup/bulk/route.ts
+++ b/src/app/api/lookup/bulk/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import { POST as urlPost } from "../url/route";
+import { POST as doiPost } from "../doi/route";
+import { POST as isbnPost } from "../isbn/route";
+
 
 interface LookupResult {
   input: string;
@@ -22,7 +26,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Refactored to process lookups concurrently for performance improvement
-    const baseUrl = request.nextUrl.origin;
+
 
     const lookupPromises = items.map(async (item) => {
       const trimmedItem = item.trim();
@@ -52,12 +56,24 @@ export async function POST(request: NextRequest) {
           };
         }
 
-        // Make the API call
-        const response = await fetch(`${baseUrl}${apiEndpoint}`, {
+        // Call the route handler directly instead of performing a loopback HTTP request,
+        // which prevents Host-header Server-Side Request Forgery (SSRF) vulnerabilities.
+        const mockRequest = new NextRequest(new URL("http://localhost" + apiEndpoint), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),
         });
+
+        let response;
+        if (apiEndpoint === "/api/lookup/url") {
+          response = await urlPost(mockRequest);
+        } else if (apiEndpoint === "/api/lookup/doi") {
+          response = await doiPost(mockRequest);
+        } else if (apiEndpoint === "/api/lookup/isbn") {
+          response = await isbnPost(mockRequest);
+        } else {
+          throw new Error("Unknown endpoint");
+        }
 
         const data = await response.json();
 


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability: The bulk lookup API (`src/app/api/lookup/bulk/route.ts`) made loopback HTTP fetch requests (`fetch(\`\${request.nextUrl.origin}\${apiEndpoint}\`)`) to downstream endpoint handlers. Because `request.nextUrl.origin` inherits from the client-provided `Host` header, an attacker could inject an arbitrary `Host` value (like `attacker.com`), tricking the server into making SSRF requests to external domains.

🎯 Impact: An attacker could perform internal port scanning, query local metadata services (e.g., AWS IMDS), or launch external attacks using the server's IP address. It also allowed potential Cache Poisoning via the Host Header.

🔧 Fix: Removed the internal loopback `fetch`. The downstream handlers (`url/route`, `doi/route`, `isbn/route`) are now explicitly imported and invoked directly with a synthetic `NextRequest` containing a static loopback URL (`http://localhost...`).

✅ Verification: The tests have been updated to test mock handler function invocations instead of `global.fetch`. Executed `pnpm test:run` and all unit tests successfully pass. Documented finding in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [9615007454723866770](https://jules.google.com/task/9615007454723866770) started by @aicoder2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security vulnerability in the bulk lookup API affecting how internal requests are processed during per-item lookups, ensuring safer request handling throughout the pipeline.

* **Tests**
  * Enhanced test coverage for bulk lookup operations with improved assertions on handler invocations across URL, DOI, and ISBN lookup routes, ensuring correct data flow through each handler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->